### PR TITLE
feature : 토큰 유효시간 조정 및 모임을 초대코드로 참여할 수 있도록 수정

### DIFF
--- a/src/main/java/org/dallyeo/matuabom/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/controller/MeetingController.java
@@ -145,6 +145,37 @@ public class MeetingController {
     }
 
     // -------------------------------------------------------------------------
+    // 모임 초대 코드
+    // -------------------------------------------------------------------------
+
+    /** 모임 초대 코드 조회 (호스트 전용) */
+    @GetMapping("/{meetingId}/invite-code")
+    public ResponseEntity<Map<String, String>> getMeetingInviteCode(
+        @PathVariable String meetingId,
+        @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        Meeting meeting = meetingService.findById(meetingId);
+        if (!meeting.getHostUserId().equals(principal.getUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        return ResponseEntity.ok(Map.of("inviteCode", meeting.getInviteCode() != null ? meeting.getInviteCode() : ""));
+    }
+
+    /** 초대 코드로 모임 참여 */
+    @PostMapping("/join")
+    public ResponseEntity<Meeting> joinByInviteCode(
+        @AuthenticationPrincipal CustomPrincipal principal,
+        @RequestBody Map<String, String> body
+    ) {
+        String inviteCode = body.get("inviteCode");
+        if (inviteCode == null || inviteCode.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        Meeting meeting = meetingService.joinByInviteCode(principal.getUserId(), inviteCode.trim());
+        return ResponseEntity.ok(meeting);
+    }
+
+    // -------------------------------------------------------------------------
     // 모임 상태 변경 (PENDING / CONFIRMED / CLOSED)
     // -------------------------------------------------------------------------
 

--- a/src/main/java/org/dallyeo/matuabom/meeting/domain/Meeting.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/domain/Meeting.java
@@ -20,6 +20,7 @@ public class Meeting {
     private String id;
     private String hostUserId;
     private String name;
+    private String inviteCode; // 모임 초대 코드 (8자리)
     /**
      * 상태:
      * - PENDING   : 투표/조율 중

--- a/src/main/java/org/dallyeo/matuabom/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/repository/MeetingRepository.java
@@ -5,10 +5,15 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MeetingRepository extends MongoRepository<Meeting, String> {
 
     List<Meeting> findAllByHostUserIdOrParticipantsUserId(String hostId, String participantId);
+
+    Optional<Meeting> findByInviteCode(String inviteCode);
+
+    boolean existsByInviteCode(String inviteCode);
 
     @Query("{ $and: [ { $or: [ { 'hostUserId': ?0 }, { 'participants.userId': ?0 } ] }, { 'name': { $regex: ?1, $options: 'i' } } ] }")
     List<Meeting> searchByTitle(String userId, String keyword);

--- a/src/main/java/org/dallyeo/matuabom/meeting/service/MeetingService.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/service/MeetingService.java
@@ -64,10 +64,13 @@ public class MeetingService {
             .findFirst()
             .ifPresent(hostParticipant -> recalculateParticipantSchedules(hostParticipant, requirement));
 
+        String inviteCode = generateUniqueInviteCode();
+
         Meeting meeting = Meeting.builder()
             .hostUserId(hostUserId)
             .name(request.getName())
             .status("PENDING")
+            .inviteCode(inviteCode)
             .requirement(requirement)
             .participants(participants)
             .build();
@@ -507,6 +510,51 @@ public class MeetingService {
     // -------------------------------------------------------------------------
     // 내부 헬퍼
     // -------------------------------------------------------------------------
+
+    private String generateUniqueInviteCode() {
+        String chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+        Random random = new Random();
+        while (true) {
+            StringBuilder sb = new StringBuilder(8);
+            for (int i = 0; i < 8; i++) sb.append(chars.charAt(random.nextInt(chars.length())));
+            String code = sb.toString();
+            if (!meetingRepository.existsByInviteCode(code)) return code;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // 모임 코드로 참여
+    // -------------------------------------------------------------------------
+
+    @Transactional
+    public Meeting joinByInviteCode(String userId, String inviteCode) {
+        Meeting meeting = meetingRepository.findByInviteCode(inviteCode.toUpperCase())
+            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 초대 코드입니다."));
+
+        if (!"PENDING".equals(meeting.getStatus())) {
+            throw new IllegalStateException("조율 중인 모임에만 참여할 수 있습니다.");
+        }
+
+        boolean alreadyJoined = meeting.getParticipants().stream()
+            .anyMatch(p -> p.getUserId().equals(userId));
+        if (alreadyJoined) {
+            throw new IllegalStateException("이미 참여한 모임입니다.");
+        }
+
+        UserEntity user = userRepository.findByMongoId(userId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+
+        MeetingParticipant newParticipant = new MeetingParticipant();
+        newParticipant.setUserId(userId);
+        newParticipant.setName(user.getNickname());
+        newParticipant.setStatus("ACCEPTED");
+        newParticipant.setTimeStatuses(new ArrayList<>());
+        newParticipant.setReflectTimetable(true);
+        newParticipant.setReflectCalendar(true);
+
+        meeting.getParticipants().add(newParticipant);
+        return meetingRepository.save(meeting);
+    }
 
     private void recalculateParticipantSchedules(MeetingParticipant participant, MeetingRequirement requirement) {
         List<ParticipantTimeStatus> fixedImpossibleStatuses =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,8 +96,8 @@ app:
   backend-base-url: ${BACKEND_BASE_URL:http://localhost:8080}
   cookie-secure: ${COOKIE_SECURE:false}
   jwt:
-    access-token-seconds: 3600       # 1시간
-    refresh-token-seconds: 1296000   # 15일
+    access-token-seconds: 7200        # 2시간
+    refresh-token-seconds: 2592000    # 30일
 
 # ── Actuator (헬스체크 전용) ───────────────────────────────────────────
 management:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #61 

## 📝 작업 내용
1. 모임 일정을 확정할 때, 확정일의 시간을 설정하는 게 아니라 종일로 설정할 수 있도록 했습니다.
2. JWT 토큰의 유효시간을 연장했습니다.
3. 모임에 초대할 때 친구가 아니어도 가능하도록. (초대코드 or 링크 등 사용) -> 모임에 친구 초대 필수 인원 제거했습니다.

> 작업내용 설명

### ✨ 스크린샷

### 💬 리뷰 요구사항
