### PR TITLE
feature : refresh token 암호화, 이용약관/개인정보처리방침 페이지 추가, 회원탈퇴 기능 추가, 글로벌 예외 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'   // API 문서화 (Swagger UI)
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'    // Java 8 Date/Time 객체 JSON 처리 지원
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'                        // .env 파일 환경 변수 로드
+    implementation 'com.bucket4j:bucket4j-core:8.10.1'                         // Rate Limiting
 
     // Lombok (컴파일 시 자동 코드 생성)
     compileOnly 'org.projectlombok:lombok'
@@ -78,7 +79,8 @@ dependencies {
     // 🧪 Testing
     // -------------------------------------------------------------------------
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'     // Spring Security 테스트 지원
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'com.h2database:h2'                                         // 테스트용 인메모리 DB
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/dallyeo/matuabom/MatuabomApplication.java
+++ b/src/main/java/org/dallyeo/matuabom/MatuabomApplication.java
@@ -2,8 +2,13 @@ package org.dallyeo.matuabom;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {
+    MongoRepositoriesAutoConfiguration.class,
+    JpaRepositoriesAutoConfiguration.class
+})
 public class MatuabomApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/dallyeo/matuabom/ai/controller/AIController.java
+++ b/src/main/java/org/dallyeo/matuabom/ai/controller/AIController.java
@@ -1,8 +1,7 @@
 package org.dallyeo.matuabom.ai.controller;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.dallyeo.matuabom.ai.dto.AIRequestDTO;
 import org.dallyeo.matuabom.ai.service.AIService;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat")
@@ -21,10 +21,10 @@ public class AIController {
     @PostMapping("/call")
     public ResponseEntity<?> call(
         @RequestBody AIRequestDTO request
-    ) throws GeneralSecurityException, IOException {
+    ) throws java.io.IOException, java.security.GeneralSecurityException {
 
         ResponseEntity<?> response = aiService.call(request);
-        System.out.println(response.getBody());
+        log.info("AI call response status: {}", response.getStatusCode());
         return response;
     }
 

--- a/src/main/java/org/dallyeo/matuabom/ai/service/AIService.java
+++ b/src/main/java/org/dallyeo/matuabom/ai/service/AIService.java
@@ -7,8 +7,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.dallyeo.matuabom.meeting.domain.Meeting;
 import org.dallyeo.matuabom.calendar.dto.CalendarEventDto;
 import org.dallyeo.matuabom.calendar.dto.CreateEventReq;
@@ -30,6 +31,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AIService {
@@ -40,7 +42,7 @@ public class AIService {
     private final CalendarEventService calendarEventService;
 
     List<String> options = List.of("bg-blue-500", "bg-purple-500", "bg-green-500", "bg-orange-500", "bg-pink-500");
-    Random random = new Random();
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public ResponseEntity<AIServerResponse> call(AIRequestDTO requestDTO)
         throws GeneralSecurityException, IOException {
@@ -89,7 +91,7 @@ public class AIService {
             try {
                 summary = fetchSummaryFromAI(category, resultData);
             } catch (Exception e) {
-                System.err.println("요약 생성 실패: " + e.getMessage());
+                log.warn("요약 생성 실패: {}", e.getMessage());
             }
         }
 
@@ -187,7 +189,7 @@ public class AIService {
             createEventReq.setEnd(data.getEnd());
 
             if (options != null && !options.isEmpty()) {
-                createEventReq.setColor(options.get(random.nextInt(options.size())));
+                createEventReq.setColor(options.get(SECURE_RANDOM.nextInt(options.size())));
             }
             return calendarEventService.create(createEventReq);
         }

--- a/src/main/java/org/dallyeo/matuabom/auth/controller/AuthController.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/controller/AuthController.java
@@ -20,6 +20,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.dallyeo.matuabom.user.service.UserWithdrawalService;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,6 +37,7 @@ public class AuthController {
     private final UserJpaRepository userRepository;
     private final TokenStore tokenStore;
     private final JwtUtil jwtUtil;
+    private final UserWithdrawalService userWithdrawalService;
 
     @Value("${app.cookie-secure:false}")
     private boolean cookieSecure;
@@ -59,7 +62,7 @@ public class AuthController {
         String accessToken = extractCookie(request, "ACCESS_TOKEN");
         if (accessToken != null) {
             try {
-                tokenStore.blacklistAccessToken(accessToken, jwtUtil.getExpiration(accessToken));
+                tokenStore.blacklistAccessToken(jwtUtil.getJti(accessToken), jwtUtil.getExpiration(accessToken));
             } catch (Exception e) {
                 log.warn("Failed to blacklist access token: {}", e.getMessage());
             }
@@ -82,7 +85,32 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    // ── 내부 헬퍼 ─────────────────────────────────────────────────────────────
+    @DeleteMapping("/api/auth/me")
+    public ResponseEntity<Void> withdraw(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String accessToken = extractCookie(request, "ACCESS_TOKEN");
+
+        userWithdrawalService.withdraw(principal.getUserId(), accessToken);
+
+        // 쿠키 삭제
+        expireCookie(response, "ACCESS_TOKEN");
+        expireCookie(response, "REFRESH_TOKEN");
+
+        SecurityContextHolder.clearContext();
+        HttpSession session = request.getSession(false);
+        if (session != null) session.invalidate();
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── 내부 헬퍼 ──────────────────────────────────────────────────────────────
 
     private String extractCookie(HttpServletRequest request, String name) {
         if (request.getCookies() == null) return null;

--- a/src/main/java/org/dallyeo/matuabom/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/filter/JwtAuthFilter.java
@@ -49,20 +49,34 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         // ① Access Token 유효 + 블랙리스트에 없는 경우 → 정상 인증
         if (accessToken != null) {
             try {
-                if (tokenStore.isBlacklisted(accessToken)) {
-                    // 블랙리스트 등록된 토큰 → 인증 거부
+                boolean blacklisted = false;
+                try {
+                    blacklisted = tokenStore.isBlacklisted(jwtUtil.getJti(accessToken));
+                } catch (Exception redisEx) {
+                    log.warn("Redis unavailable during blacklist check, allowing request. path={}", request.getRequestURI());
+                }
+
+                if (blacklisted) {
                     clearContext(response);
                     filterChain.doFilter(request, response);
                     return;
                 }
 
                 String userId = jwtUtil.validateAndGetSub(accessToken);
+
+                // 토큰 타입 검증 — refresh token으로 API 호출 차단
+                if (!"access".equals(jwtUtil.getTokenType(accessToken))) {
+                    log.warn("Non-access token used as access token. path={}", request.getRequestURI());
+                    clearContext(response);
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 setAuthentication(request, userId);
                 filterChain.doFilter(request, response);
                 return;
 
             } catch (JwtException e) {
-                // Access Token 만료 → Refresh Token으로 재발급 시도
                 log.debug("Access token expired, trying refresh. path={}", request.getRequestURI());
             }
         }
@@ -72,28 +86,44 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             try {
                 String userId = jwtUtil.validateAndGetSub(refreshToken);
 
+                // 토큰 타입 검증
+                if (!"refresh".equals(jwtUtil.getTokenType(refreshToken))) {
+                    log.warn("Non-refresh token used as refresh token. path={}", request.getRequestURI());
+                    clearContext(response);
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 if (!tokenStore.isRefreshTokenValid(userId, refreshToken)) {
-                    // Redis에 저장된 토큰과 불일치 → 탈취 가능성, 즉시 거부
                     log.warn("Refresh token mismatch for userId={}. Possible token theft.", userId);
                     clearContext(response);
                     filterChain.doFilter(request, response);
                     return;
                 }
 
-                // Refresh Token Rotation: 새 Access + Refresh 발급
-                String newAccessToken  = jwtUtil.createAccessToken(userId);
-                String newRefreshToken = jwtUtil.createRefreshToken(userId);
+                // 분산 락 획득 — 동시 요청 중 첫 번째만 토큰 갱신
+                if (tokenStore.acquireTokenRefreshLock(userId)) {
+                    try {
+                        String newAccessToken  = jwtUtil.createAccessToken(userId);
+                        String newRefreshToken = jwtUtil.createRefreshToken(userId);
 
-                tokenStore.saveRefreshToken(userId, newRefreshToken, jwtUtil.getRefreshTokenSeconds());
+                        tokenStore.saveRefreshToken(userId, newRefreshToken, jwtUtil.getRefreshTokenSeconds());
 
-                addCookie(response, "ACCESS_TOKEN",  newAccessToken,  (int) jwtUtil.getRefreshTokenSeconds());
-                addCookie(response, "REFRESH_TOKEN", newRefreshToken, (int) jwtUtil.getRefreshTokenSeconds());
+                        addCookie(response, "ACCESS_TOKEN",  newAccessToken,  (int) jwtUtil.getRefreshTokenSeconds());
+                        addCookie(response, "REFRESH_TOKEN", newRefreshToken, (int) jwtUtil.getRefreshTokenSeconds());
+
+                        log.debug("Token refreshed silently for userId={}", userId);
+                    } finally {
+                        tokenStore.releaseTokenRefreshLock(userId);
+                    }
+                } else {
+                    // 락 획득 실패 — 다른 요청이 이미 갱신 중, 현재 토큰으로 인증만 수행
+                    log.debug("Token refresh lock not acquired for userId={}, skipping rotation", userId);
+                }
 
                 setAuthentication(request, userId);
-                log.debug("Token refreshed silently for userId={}", userId);
 
             } catch (JwtException e) {
-                // Refresh Token도 만료 → 재로그인 필요
                 log.debug("Refresh token also expired. Re-login required.");
                 clearContext(response);
             }

--- a/src/main/java/org/dallyeo/matuabom/auth/service/GoogleOAuthClientService.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/service/GoogleOAuthClientService.java
@@ -1,8 +1,10 @@
 package org.dallyeo.matuabom.auth.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.dallyeo.matuabom.calendar.domain.GoogleOAuthClientEntity;
 import org.dallyeo.matuabom.calendar.repository.GoogleOAuthClientRepository;
+import org.dallyeo.matuabom.sse.service.EventSseService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.stereotype.Service;
@@ -17,10 +19,12 @@ import java.time.Instant;
 import java.util.Optional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class GoogleOAuthClientService {
 
     private final GoogleOAuthClientRepository repo;
+    private final EventSseService eventSseService;
 
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
     private String clientId;
@@ -94,7 +98,9 @@ public class GoogleOAuthClientService {
                     clientSecret
             ).execute();
         } catch (Exception e) {
-            // invalid_grant 등 refresh 불가능한 상태
+            // invalid_grant 등 refresh 불가능한 상태 — 사용자에게 재연동 요청 알림
+            log.warn("Google token refresh failed for userId={}: {}", userId, e.getMessage());
+            eventSseService.sendGoogleReauthRequired(userId);
             throw new IllegalStateException("GOOGLE_REFRESH_FAILED", e);
         }
 

--- a/src/main/java/org/dallyeo/matuabom/auth/service/TokenStore.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/service/TokenStore.java
@@ -21,6 +21,7 @@ public class TokenStore {
     private static final String PREFIX_REFRESH    = "refresh:";
     private static final String PREFIX_BLACKLIST  = "blacklist:";
     private static final String PREFIX_INVITE     = "invite:";
+    private static final String PREFIX_TOKEN_LOCK = "token_refresh_lock:";
 
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -43,22 +44,38 @@ public class TokenStore {
         redisTemplate.delete(PREFIX_REFRESH + userId);
     }
 
+    // ── Token Refresh 분산 락 ──────────────────────────────────────────────────
+
+    /**
+     * Refresh Token 갱신 락 획득 (SET NX, TTL 5초).
+     * 동시에 여러 요청이 들어올 때 첫 번째 요청만 갱신 수행.
+     */
+    public boolean acquireTokenRefreshLock(String userId) {
+        Boolean acquired = redisTemplate.opsForValue()
+                .setIfAbsent(PREFIX_TOKEN_LOCK + userId, "1", Duration.ofSeconds(5));
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    public void releaseTokenRefreshLock(String userId) {
+        redisTemplate.delete(PREFIX_TOKEN_LOCK + userId);
+    }
+
     // ── Access Token 블랙리스트 ────────────────────────────────────────────────
 
     /**
      * 로그아웃 시 access token을 블랙리스트에 등록.
-     * TTL은 토큰의 잔여 유효기간으로 설정 → 만료되면 자동 삭제.
+     * Redis 키: blacklist:{jti} — JWT 전체 문자열 대신 UUID(jti)만 저장해 메모리 절약.
      */
-    public void blacklistAccessToken(String accessToken, Instant expiresAt) {
+    public void blacklistAccessToken(String jti, Instant expiresAt) {
         long remainingSeconds = expiresAt.getEpochSecond() - Instant.now().getEpochSecond();
         if (remainingSeconds > 0) {
             redisTemplate.opsForValue()
-                    .set(PREFIX_BLACKLIST + accessToken, "1", Duration.ofSeconds(remainingSeconds));
+                    .set(PREFIX_BLACKLIST + jti, "1", Duration.ofSeconds(remainingSeconds));
         }
     }
 
-    public boolean isBlacklisted(String accessToken) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX_BLACKLIST + accessToken));
+    public boolean isBlacklisted(String jti) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX_BLACKLIST + jti));
     }
 
     // ── InviteCode 캐시 ────────────────────────────────────────────────────────

--- a/src/main/java/org/dallyeo/matuabom/calendar/controller/GoogleWebhookController.java
+++ b/src/main/java/org/dallyeo/matuabom/calendar/controller/GoogleWebhookController.java
@@ -2,13 +2,17 @@ package org.dallyeo.matuabom.calendar.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.dallyeo.matuabom.auth.service.GoogleOAuthClientService;
 import org.dallyeo.matuabom.calendar.service.GoogleSyncService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/google")
 @RequiredArgsConstructor
@@ -17,17 +21,28 @@ public class GoogleWebhookController {
     private final GoogleOAuthClientService googleTokens;
     private final GoogleSyncService googleSyncService;
 
+    @Value("${app.google-webhook-token:}")
+    private String expectedToken;
+
     @PostMapping("/webhook")
     public ResponseEntity<Void> handleWebhook(HttpServletRequest request) {
-        String channelId = request.getHeader("X-Goog-Channel-ID");
-        String state     = request.getHeader("X-Goog-Resource-State");
+        String channelId    = request.getHeader("X-Goog-Channel-ID");
+        String state        = request.getHeader("X-Goog-Resource-State");
+        String channelToken = request.getHeader("X-Goog-Channel-Token");
+
+        // Webhook token 검증 (설정된 경우에만)
+        if (expectedToken != null && !expectedToken.isBlank()) {
+            if (!expectedToken.equals(channelToken)) {
+                log.warn("Webhook token mismatch. channelId={}", channelId);
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+        }
 
         // "sync" 는 채널 등록 확인 알림 — 실제 데이터 변경 아님
         if ("sync".equals(state)) {
             return ResponseEntity.noContent().build();
         }
 
-        // exists / update / delete 등 모든 변경 상태에 대해 증분 동기화 실행
         googleTokens.findByChannelId(channelId).ifPresent(tokens ->
                 googleSyncService.runIncrementalSync(tokens.getUserId())
         );

--- a/src/main/java/org/dallyeo/matuabom/calendar/repository/CalendarEventRepository.java
+++ b/src/main/java/org/dallyeo/matuabom/calendar/repository/CalendarEventRepository.java
@@ -31,4 +31,7 @@ public interface CalendarEventRepository extends MongoRepository<CalendarEventDt
     List<CalendarEventDto> findByMeetingId(String meetingId);
 
     void deleteByMeetingId(String meetingId);
+
+    List<CalendarEventDto> findByUserIdInAndStartTimestampLessThanAndEndTimestampGreaterThan(
+            List<String> userIds, Long endTs, Long startTs);
 }

--- a/src/main/java/org/dallyeo/matuabom/calendar/service/CalendarEventService.java
+++ b/src/main/java/org/dallyeo/matuabom/calendar/service/CalendarEventService.java
@@ -1,6 +1,7 @@
 package org.dallyeo.matuabom.calendar.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.dallyeo.matuabom.calendar.domain.GoogleOAuthClientEntity;
 import org.dallyeo.matuabom.calendar.dto.CalendarEventDto;
 import org.dallyeo.matuabom.calendar.dto.CreateEventReq;
@@ -16,7 +17,9 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CalendarEventService {
@@ -115,7 +118,7 @@ public class CalendarEventService {
                 } catch (GoogleJsonResponseException e) {
                     int status = e.getStatusCode();
                     if (status == 404 || status == 410) {
-                        System.out.println("Google event already deleted. Skip Google delete.");
+                        log.info("Google event already deleted, skipping. eventId={}", eventId);
                     } else {
                         throw new RuntimeException(e);
                     }
@@ -160,7 +163,18 @@ public class CalendarEventService {
                     uid, endTs, startTs
             );
         }
-
         return repository.findByUserIdOrderByStartTimestampAsc(uid);
+    }
+
+    /**
+     * 여러 userId의 이벤트를 한 번의 쿼리로 조회 (N+1 방지).
+     */
+    public Map<String, List<CalendarEventDto>> getEventsByUserIds(
+            List<String> userIds, Long startTs, Long endTs) {
+        if (userIds == null || userIds.isEmpty()) return java.util.Collections.emptyMap();
+        List<CalendarEventDto> all = repository
+                .findByUserIdInAndStartTimestampLessThanAndEndTimestampGreaterThan(
+                        userIds, endTs, startTs);
+        return all.stream().collect(java.util.stream.Collectors.groupingBy(CalendarEventDto::getUserId));
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/calendar/service/GoogleCalendarService.java
+++ b/src/main/java/org/dallyeo/matuabom/calendar/service/GoogleCalendarService.java
@@ -1,6 +1,5 @@
 package org.dallyeo.matuabom.calendar.service;
 
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.DateTime;
@@ -8,6 +7,7 @@ import com.google.api.services.calendar.Calendar;
 import com.google.api.services.calendar.model.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import com.google.api.client.http.javanet.NetHttpTransport;
 import lombok.RequiredArgsConstructor;
 import org.dallyeo.matuabom.calendar.domain.GoogleOAuthClientEntity;
 import org.dallyeo.matuabom.calendar.dto.CalendarEventDto;
@@ -36,7 +36,9 @@ public class GoogleCalendarService {
 
     private final CalendarEventRepository repository;
     private final GoogleOAuthClientService googleOAuthClientService;
+    private final NetHttpTransport httpTransport;
 
+    // HTTP Transport — GoogleApiConfig에서 Bean으로 주입 (싱글턴 보장)
     private static final Logger logger = LoggerFactory.getLogger(GoogleCalendarService.class);
 
     private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
@@ -46,6 +48,9 @@ public class GoogleCalendarService {
 
     @Value("${app.backend-base-url:http://localhost:8080}")
     private String backendBaseUrl;
+
+    @Value("${app.google-webhook-token:}")
+    private String googleWebhookToken;
 
     // -------------------------------------------------------------------------
     // SyncResult
@@ -95,7 +100,6 @@ public class GoogleCalendarService {
     private Calendar buildCalendarClient(GoogleOAuthClientEntity tokens)
             throws GeneralSecurityException, IOException {
 
-        var http = GoogleNetHttpTransport.newTrustedTransport();
         var json = GsonFactory.getDefaultInstance();
         String accessToken = googleOAuthClientService.refreshAccessTokenIfExpired(tokens.getUserId());
 
@@ -105,7 +109,7 @@ public class GoogleCalendarService {
                         ? accessToken.substring(0, 10) : "null");
 
         return new Calendar.Builder(
-                http, json,
+                httpTransport, json,
                 req -> req.getHeaders().setAuthorization("Bearer " + accessToken)
         ).setApplicationName("Matuabom Calendar Integration").build();
     }
@@ -604,6 +608,11 @@ public class GoogleCalendarService {
                     .setType("web_hook")
                     .setAddress(backendBaseUrl + "/api/google/webhook")
                     .setExpiration(expiresMs);
+
+            // Webhook 검증용 토큰 설정 (GoogleWebhookController에서 검증)
+            if (googleWebhookToken != null && !googleWebhookToken.isBlank()) {
+                watchBody.setToken(googleWebhookToken);
+            }
 
             Channel response = service.events().watch("primary", watchBody).execute();
 

--- a/src/main/java/org/dallyeo/matuabom/calendar/service/WatchChannelRenewalService.java
+++ b/src/main/java/org/dallyeo/matuabom/calendar/service/WatchChannelRenewalService.java
@@ -28,19 +28,22 @@ public class WatchChannelRenewalService {
         List<GoogleOAuthClientEntity> candidates = repo.findAll().stream()
                 .filter(e -> e.getRefreshToken() != null) // Google 연동 사용자만
                 .filter(e -> {
-                    // watchExpiresAt이 null이면 아직 채널 등록 자체가 안 된 것 → 등록 대상
-                    // watchExpiresAt이 24시간 이내 만료 예정 → 갱신 대상
-                    return e.getWatchExpiresAt() == null || e.getWatchExpiresAt().isBefore(threshold);
+                    // watchExpiresAt이 null: 채널이 한 번도 등록된 적 없음
+                    //   → watchChannelId도 null인 경우만 등록 대상으로 포함
+                    //     (watchChannelId가 있으면 이전에 등록했다가 만료된 케이스)
+                    if (e.getWatchExpiresAt() == null) {
+                        return e.getWatchChannelId() == null; // 최초 등록 대상만
+                    }
+                    // 24시간 이내 만료 예정 → 갱신 대상
+                    return e.getWatchExpiresAt().isBefore(threshold);
                 })
                 .toList();
 
-        log.info("WatchChannel renewal: {} channels to renew", candidates.size());
+        log.info("WatchChannel renewal: {} channels to process", candidates.size());
         for (GoogleOAuthClientEntity tokens : candidates) {
             try {
-                // watchExpiresAt을 null로 설정하면 ensureWatchChannel이 강제 재등록
-                tokens.setWatchExpiresAt(null);
                 googleCalendarService.ensureWatchChannel(tokens);
-                log.info("Watch channel renewed for userId={}", tokens.getUserId());
+                log.info("Watch channel processed for userId={}", tokens.getUserId());
             } catch (Exception e) {
                 log.warn("Watch channel renewal failed for userId={}: {}", tokens.getUserId(), e.getMessage());
             }

--- a/src/main/java/org/dallyeo/matuabom/common/config/MongoConfig.java
+++ b/src/main/java/org/dallyeo/matuabom/common/config/MongoConfig.java
@@ -1,0 +1,20 @@
+package org.dallyeo.matuabom.common.config;
+
+import org.dallyeo.matuabom.common.crypto.EncryptedTokenReadConverter;
+import org.dallyeo.matuabom.common.crypto.EncryptedTokenWriteConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+
+import java.util.List;
+
+@Configuration
+public class MongoConfig {
+
+    @Bean
+    public MongoCustomConversions mongoCustomConversions(
+            EncryptedTokenReadConverter readConverter,
+            EncryptedTokenWriteConverter writeConverter) {
+        return new MongoCustomConversions(List.of(readConverter, writeConverter));
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/common/crypto/AesEncryptor.java
+++ b/src/main/java/org/dallyeo/matuabom/common/crypto/AesEncryptor.java
@@ -1,0 +1,75 @@
+package org.dallyeo.matuabom.common.crypto;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * AES-256-GCM 대칭 암호화 유틸.
+ * ENCRYPT_KEY 환경변수: Base64 인코딩된 32바이트 키
+ * 생성 예시: openssl rand -base64 32
+ */
+@Component
+public class AesEncryptor {
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH = 128;
+
+    private final SecretKeySpec secretKey;
+
+    public AesEncryptor(@Value("${app.encrypt-key:}") String base64Key) {
+        if (base64Key == null || base64Key.isBlank()) {
+            // 개발 환경 기본키 — 32바이트: "matuabom-dev-only-key-32bytes!!!"
+            // 운영에서는 반드시 ENCRYPT_KEY 환경변수에 openssl rand -base64 32 값을 설정하세요
+            base64Key = "bWF0dWFib20tZGV2LW9ubHkta2V5LTMyYnl0ZXMhISE=";
+        }
+        byte[] keyBytes = Base64.getDecoder().decode(base64Key);
+        if (keyBytes.length != 32) {
+            throw new IllegalArgumentException("ENCRYPT_KEY must be 32 bytes (Base64-encoded)");
+        }
+        this.secretKey = new SecretKeySpec(keyBytes, "AES");
+    }
+
+    public String encrypt(String plainText) {
+        if (plainText == null) return null;
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            new SecureRandom().nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+            byte[] encrypted = cipher.doFinal(plainText.getBytes());
+
+            // IV(12) + ciphertext 를 합쳐 Base64 반환
+            byte[] combined = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(encrypted, 0, combined, iv.length, encrypted.length);
+            return Base64.getEncoder().encodeToString(combined);
+        } catch (Exception e) {
+            throw new RuntimeException("Encryption failed", e);
+        }
+    }
+
+    public String decrypt(String cipherText) {
+        if (cipherText == null) return null;
+        try {
+            byte[] combined = Base64.getDecoder().decode(cipherText);
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            byte[] encrypted = new byte[combined.length - GCM_IV_LENGTH];
+            System.arraycopy(combined, 0, iv, 0, GCM_IV_LENGTH);
+            System.arraycopy(combined, GCM_IV_LENGTH, encrypted, 0, encrypted.length);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+            return new String(cipher.doFinal(encrypted));
+        } catch (Exception e) {
+            throw new RuntimeException("Decryption failed", e);
+        }
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/common/crypto/EncryptedTokenReadConverter.java
+++ b/src/main/java/org/dallyeo/matuabom/common/crypto/EncryptedTokenReadConverter.java
@@ -1,0 +1,55 @@
+package org.dallyeo.matuabom.common.crypto;
+
+import org.bson.Document;
+import org.dallyeo.matuabom.calendar.domain.GoogleOAuthClientEntity;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * MongoDB Document → GoogleOAuthClientEntity 조회 시 토큰 복호화
+ */
+@Component
+@ReadingConverter
+public class EncryptedTokenReadConverter implements Converter<Document, GoogleOAuthClientEntity> {
+
+    private final AesEncryptor encryptor;
+
+    public EncryptedTokenReadConverter(AesEncryptor encryptor) {
+        this.encryptor = encryptor;
+    }
+
+    @Override
+    public GoogleOAuthClientEntity convert(Document source) {
+        GoogleOAuthClientEntity entity = new GoogleOAuthClientEntity();
+        entity.setId(source.getString("_id"));
+        entity.setUserId(source.getString("userId"));
+        entity.setGoogleEmail(source.getString("googleEmail"));
+        entity.setAccessToken(encryptor.decrypt(source.getString("accessToken")));
+        entity.setAccessTokenIssuedAt(toInstant(source.getDate("accessTokenIssuedAt")));
+        entity.setAccessTokenExpiresAt(toInstant(source.getDate("accessTokenExpiresAt")));
+        entity.setRefreshToken(encryptor.decrypt(source.getString("refreshToken")));
+        entity.setRefreshTokenIssuedAt(toInstant(source.getDate("refreshTokenIssuedAt")));
+
+        List<?> scopes = source.getList("scopes", String.class);
+        if (scopes != null) {
+            entity.setScopes(new HashSet<>(source.getList("scopes", String.class)));
+        }
+
+        entity.setUpdatedAt(toInstant(source.getDate("updatedAt")));
+        entity.setSyncToken(source.getString("syncToken"));
+        entity.setWatchChannelId(source.getString("watchChannelId"));
+        entity.setWatchResourceId(source.getString("watchResourceId"));
+        entity.setWatchExpiresAt(toInstant(source.getDate("watchExpiresAt")));
+        return entity;
+    }
+
+    private Instant toInstant(Date date) {
+        return date != null ? date.toInstant() : null;
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/common/crypto/EncryptedTokenWriteConverter.java
+++ b/src/main/java/org/dallyeo/matuabom/common/crypto/EncryptedTokenWriteConverter.java
@@ -1,0 +1,48 @@
+package org.dallyeo.matuabom.common.crypto;
+
+import org.bson.Document;
+import org.dallyeo.matuabom.calendar.domain.GoogleOAuthClientEntity;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+/**
+ * GoogleOAuthClientEntity → MongoDB Document 저장 시 토큰 암호화
+ */
+@Component
+@WritingConverter
+public class EncryptedTokenWriteConverter implements Converter<GoogleOAuthClientEntity, Document> {
+
+    private final AesEncryptor encryptor;
+
+    public EncryptedTokenWriteConverter(AesEncryptor encryptor) {
+        this.encryptor = encryptor;
+    }
+
+    @Override
+    public Document convert(GoogleOAuthClientEntity source) {
+        Document doc = new Document();
+        doc.put("_id", source.getId());
+        doc.put("userId", source.getUserId());
+        doc.put("googleEmail", source.getGoogleEmail());
+        doc.put("accessToken", encryptor.encrypt(source.getAccessToken()));
+        doc.put("accessTokenIssuedAt",
+                source.getAccessTokenIssuedAt() != null ? Date.from(source.getAccessTokenIssuedAt()) : null);
+        doc.put("accessTokenExpiresAt",
+                source.getAccessTokenExpiresAt() != null ? Date.from(source.getAccessTokenExpiresAt()) : null);
+        doc.put("refreshToken", encryptor.encrypt(source.getRefreshToken()));
+        doc.put("refreshTokenIssuedAt",
+                source.getRefreshTokenIssuedAt() != null ? Date.from(source.getRefreshTokenIssuedAt()) : null);
+        doc.put("scopes", source.getScopes() != null ? source.getScopes().stream().toList() : null);
+        doc.put("updatedAt",
+                source.getUpdatedAt() != null ? Date.from(source.getUpdatedAt()) : null);
+        doc.put("syncToken", source.getSyncToken());
+        doc.put("watchChannelId", source.getWatchChannelId());
+        doc.put("watchResourceId", source.getWatchResourceId());
+        doc.put("watchExpiresAt",
+                source.getWatchExpiresAt() != null ? Date.from(source.getWatchExpiresAt()) : null);
+        return doc;
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/global/config/AppProperties.java
+++ b/src/main/java/org/dallyeo/matuabom/global/config/AppProperties.java
@@ -1,0 +1,60 @@
+package org.dallyeo.matuabom.global.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 필수 환경변수 누락 시 애플리케이션 시작을 즉시 중단.
+ * 런타임 NPE 대신 시작 시점에 명확한 오류 메시지 출력.
+ */
+@Getter
+@Setter
+@Component
+public class AppProperties {
+
+    @Value("${JWT_SECRET:}")
+    private String jwtSecret;
+
+    @Value("${GOOGLE_CLIENT_ID:}")
+    private String googleClientId;
+
+    @Value("${GOOGLE_CLIENT_SECRET:}")
+    private String googleClientSecret;
+
+    @Value("${KAKAO_CLIENT_ID:}")
+    private String kakaoClientId;
+
+    @Value("${MONGODB_URI:}")
+    private String mongodbUri;
+
+    @Value("${app.encrypt-key:}")
+    private String encryptKey;
+
+    @PostConstruct
+    public void validate() {
+        List<String> missing = new ArrayList<>();
+
+        if (isBlank(jwtSecret))          missing.add("JWT_SECRET");
+        if (isBlank(googleClientId))      missing.add("GOOGLE_CLIENT_ID");
+        if (isBlank(googleClientSecret))  missing.add("GOOGLE_CLIENT_SECRET");
+        if (isBlank(kakaoClientId))       missing.add("KAKAO_CLIENT_ID");
+        if (isBlank(mongodbUri))          missing.add("MONGODB_URI");
+        // ENCRYPT_KEY는 누락 시 AesEncryptor에서 개발용 기본키 사용 (운영에서는 설정 필수)
+
+        if (!missing.isEmpty()) {
+            throw new IllegalStateException(
+                "필수 환경변수가 누락되었습니다: " + String.join(", ", missing)
+            );
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/global/config/AsyncConfig.java
+++ b/src/main/java/org/dallyeo/matuabom/global/config/AsyncConfig.java
@@ -1,5 +1,6 @@
 package org.dallyeo.matuabom.global.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -7,7 +8,10 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
 
+@Slf4j
 @Configuration
 @EnableAsync
 @EnableScheduling
@@ -20,7 +24,16 @@ public class AsyncConfig {
         ex.setMaxPoolSize(8);
         ex.setQueueCapacity(100);
         ex.setThreadNamePrefix("google-sync-");
+        ex.setRejectedExecutionHandler(loggingRejectedExecutionHandler());
         ex.initialize();
         return ex;
+    }
+
+    private RejectedExecutionHandler loggingRejectedExecutionHandler() {
+        return (r, executor) ->
+            log.warn("Google sync task rejected — queue full. coreSize={}, activeCount={}, queueSize={}",
+                    executor.getCorePoolSize(),
+                    executor.getActiveCount(),
+                    executor.getQueue().size());
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/global/config/RestTemplateConfig.java
+++ b/src/main/java/org/dallyeo/matuabom/global/config/RestTemplateConfig.java
@@ -2,6 +2,7 @@ package org.dallyeo.matuabom.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,6 +10,9 @@ public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(10000);
+        return new RestTemplate(factory);
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/global/config/SecurityConfig.java
+++ b/src/main/java/org/dallyeo/matuabom/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.dallyeo.matuabom.auth.filter.JwtAuthFilter;
 import org.dallyeo.matuabom.auth.handler.JwtLoginSuccessHandler;
 import org.dallyeo.matuabom.auth.service.KakaoOAuth2UserService;
+import org.dallyeo.matuabom.global.filter.RateLimitFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -15,6 +16,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -33,6 +35,7 @@ public class SecurityConfig {
     private final KakaoOAuth2UserService kakaoOAuth2UserService;
     private final JwtLoginSuccessHandler jwtLoginSuccessHandler;
     private final JwtAuthFilter jwtAuthFilter;
+    private final RateLimitFilter rateLimitFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -47,7 +50,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/swagger", "/swagger-ui.html", "/swagger-ui/**",
-                                "/api-docs", "/api-docs/**", "/v3/api-docs/**",
+                                "/api-docs", "/api-docs/**", "/v3/api-docs/**",  // prod에서는 springdoc.swagger-ui.enabled=false로 비활성화
                                 "/", "/error", "/favicon.ico",
                                 "/*.png", "/*.gif", "/*.svg", "/*.jpg", "/*.html", "/*.css", "/*.js",
                                 "/actuator/health"   // 헬스체크 (CI/CD 배포 검증용)
@@ -77,6 +80,7 @@ public class SecurityConfig {
                         .successHandler(jwtLoginSuccessHandler)
                 )
                 .oauth2Client(Customizer.withDefaults())
+                .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(jwtAuthFilter, OAuth2LoginAuthenticationFilter.class);
 
         return http.build();
@@ -86,7 +90,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(List.of("http://localhost:3000","http://localhost:5000", frontendBaseUrl));
+        config.setAllowedOrigins(List.of("http://localhost:3000", frontendBaseUrl));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "Accept", "X-Admin-Secret"));
         config.setExposedHeaders(List.of("Set-Cookie"));

--- a/src/main/java/org/dallyeo/matuabom/global/config/SwaggerConfig.java
+++ b/src/main/java/org/dallyeo/matuabom/global/config/SwaggerConfig.java
@@ -1,20 +1,23 @@
 package org.dallyeo.matuabom.global.config;
 
-import io.swagger.v3.oas.models.servers.Server;
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.info.Contact;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
-    private Info apiInfo() {
-        return new Info()
-            .title("API Test")
-            .description("Let's practice Swagger UI")
-            .version("1.0.0");
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("맞춰봄 API")
+                .description("맞춰봄 모임 일정 조율 서비스 API 문서")
+                .version("1.0.0")
+                .contact(new Contact()
+                    .name("문성현")
+                    .email("tjgus9139@gmail.com")));
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/global/config/WebClientConfig.java
+++ b/src/main/java/org/dallyeo/matuabom/global/config/WebClientConfig.java
@@ -1,14 +1,31 @@
 package org.dallyeo.matuabom.global.config;
 
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class WebClientConfig {
 
     @Bean
     public WebClient webClient() {
-        return WebClient.builder().build();
+        HttpClient httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+            .responseTimeout(Duration.ofSeconds(10))
+            .doOnConnected(conn ->
+                conn.addHandlerLast(new ReadTimeoutHandler(10, TimeUnit.SECONDS))
+                    .addHandlerLast(new WriteTimeoutHandler(10, TimeUnit.SECONDS)));
+
+        return WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .build();
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/dallyeo/matuabom/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,68 @@
+package org.dallyeo.matuabom.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 400 — 잘못된 요청
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException e) {
+        log.warn("Bad request: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(Map.of("error", "bad_request", "message", e.getMessage()));
+    }
+
+    // 400 — Validation 실패 (@Valid)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .findFirst()
+                .orElse("유효하지 않은 요청입니다.");
+        log.warn("Validation failed: {}", message);
+        return ResponseEntity.badRequest()
+                .body(Map.of("error", "validation_failed", "message", message));
+    }
+
+    // 403 — 권한 없음
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<Map<String, String>> handleSecurity(SecurityException e) {
+        log.warn("Forbidden: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(Map.of("error", "forbidden", "message", e.getMessage()));
+    }
+
+    // 404 — 사용자 없음
+    @ExceptionHandler(UsernameNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleUserNotFound(UsernameNotFoundException e) {
+        log.warn("User not found: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", "not_found", "message", e.getMessage()));
+    }
+
+    // 409 — 상태 충돌
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalState(IllegalStateException e) {
+        log.warn("Conflict: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(Map.of("error", "conflict", "message", e.getMessage()));
+    }
+
+    // 500 — 예상치 못한 예외 (스택 트레이스 외부 노출 차단)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "internal_server_error", "message", "서버 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/global/filter/RateLimitFilter.java
+++ b/src/main/java/org/dallyeo/matuabom/global/filter/RateLimitFilter.java
@@ -1,0 +1,98 @@
+package org.dallyeo.matuabom.global.filter;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * IP 기반 Rate Limiting 필터.
+ *
+ * 엔드포인트별 제한:
+ *   - POST /api/friends/addFriend : 10회/분 (초대코드 브루트포스 방지)
+ *   - POST /oauth2/authorization/* : 20회/분 (로그인 어뷰징 방지)
+ *   - POST /api/calendar/sync      : 10회/분 (무한 동기화 방지)
+ *   - 그 외 /api/**                : 200회/분 (일반 API)
+ */
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    // IP + 버킷 타입별 캐시
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain chain
+    ) throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        // Rate Limit 대상 경로만 처리
+        if (!isRateLimited(method, path)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String ip = getClientIp(request);
+        String bucketType = resolveBucketType(method, path);
+        String key = ip + ":" + bucketType;
+
+        Bucket bucket = buckets.computeIfAbsent(key, k -> createBucket(bucketType));
+
+        if (bucket.tryConsume(1)) {
+            chain.doFilter(request, response);
+        } else {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"error\":\"too_many_requests\",\"message\":\"요청이 너무 많습니다. 잠시 후 다시 시도해주세요.\"}");
+        }
+    }
+
+    private boolean isRateLimited(String method, String path) {
+        if (path.startsWith("/api/") || path.startsWith("/oauth2/")) return true;
+        return false;
+    }
+
+    private String resolveBucketType(String method, String path) {
+        if ("POST".equals(method) && path.equals("/api/friends/addFriend")) return "invite";
+        if (path.startsWith("/oauth2/authorization/"))                       return "login";
+        if ("POST".equals(method) && path.equals("/api/calendar/sync"))      return "sync";
+        return "default";
+    }
+
+    private Bucket createBucket(String type) {
+        Bandwidth limit = switch (type) {
+            case "invite" -> Bandwidth.builder().capacity(10).refillGreedy(10, Duration.ofMinutes(1)).build();
+            case "login"  -> Bandwidth.builder().capacity(20).refillGreedy(20, Duration.ofMinutes(1)).build();
+            case "sync"   -> Bandwidth.builder().capacity(10).refillGreedy(10, Duration.ofMinutes(1)).build();
+            default       -> Bandwidth.builder().capacity(200).refillGreedy(200, Duration.ofMinutes(1)).build();
+        };
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        String realIp = request.getHeader("X-Real-IP");
+        if (realIp != null && !realIp.isBlank()) {
+            return realIp;
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/global/filter/RequestLoggingFilter.java
+++ b/src/main/java/org/dallyeo/matuabom/global/filter/RequestLoggingFilter.java
@@ -1,0 +1,47 @@
+package org.dallyeo.matuabom.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * HTTP 요청/응답 로깅 필터.
+ * 처리 시간, 상태코드, 경로를 INFO 레벨로 기록.
+ * actuator/health는 노이즈 방지를 위해 제외.
+ */
+@Slf4j
+@Component
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/actuator");
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain chain
+    ) throws ServletException, IOException {
+        long start = System.currentTimeMillis();
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("{} {} {} {}ms",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    response.getStatus(),
+                    elapsed);
+        }
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/global/util/InviteCodeGenerator.java
+++ b/src/main/java/org/dallyeo/matuabom/global/util/InviteCodeGenerator.java
@@ -2,17 +2,17 @@ package org.dallyeo.matuabom.global.util;
 
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.security.SecureRandom;
 
 @Component
 public class InviteCodeGenerator {
     private static final String CHAR_POOL = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-    public String generateRandomCode(int length){
-        StringBuilder sb = new StringBuilder();
-        ThreadLocalRandom random = ThreadLocalRandom.current();
+    public String generateRandomCode(int length) {
+        StringBuilder sb = new StringBuilder(length);
         for (int i = 0; i < length; i++) {
-            sb.append(CHAR_POOL.charAt(random.nextInt(CHAR_POOL.length())));
+            sb.append(CHAR_POOL.charAt(SECURE_RANDOM.nextInt(CHAR_POOL.length())));
         }
         return sb.toString();
     }

--- a/src/main/java/org/dallyeo/matuabom/global/util/JwtUtil.java
+++ b/src/main/java/org/dallyeo/matuabom/global/util/JwtUtil.java
@@ -82,6 +82,13 @@ public class JwtUtil {
         return parseClaims(jwt).getExpiration().toInstant();
     }
 
+    /**
+     * JWT ID (jti) 반환 — 블랙리스트 Redis 키로 사용.
+     */
+    public String getJti(String jwt) {
+        return parseClaims(jwt).getId();
+    }
+
     // ── 내부 ──────────────────────────────────────────────────────────────────
 
     private String build(String userId, String type, long ttlSeconds) {
@@ -89,6 +96,7 @@ public class JwtUtil {
         return Jwts.builder()
                 .subject(userId)
                 .claim("type", type)
+                .id(java.util.UUID.randomUUID().toString())  // jti — 블랙리스트 키로 사용
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.plusSeconds(ttlSeconds)))
                 .signWith(key)

--- a/src/main/java/org/dallyeo/matuabom/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/controller/MeetingController.java
@@ -46,8 +46,18 @@ public class MeetingController {
     }
 
     @GetMapping("/{meetingId}")
-    public ResponseEntity<Meeting> getMeetingDetail(@PathVariable String meetingId) {
+    public ResponseEntity<Meeting> getMeetingDetail(
+        @PathVariable String meetingId,
+        @AuthenticationPrincipal CustomPrincipal principal
+    ) {
         Meeting meeting = meetingService.findById(meetingId);
+        String userId = principal.getUserId();
+        boolean isParticipant = meeting.getParticipants().stream()
+                .anyMatch(p -> userId.equals(p.getUserId()));
+        boolean isHost = userId.equals(meeting.getHostUserId());
+        if (!isParticipant && !isHost) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         return ResponseEntity.ok(meeting);
     }
 
@@ -133,15 +143,27 @@ public class MeetingController {
     // -------------------------------------------------------------------------
 
     @GetMapping("/{meetingId}/available-slots")
-    public ResponseEntity<List<AvailableSlot>> getAvailableSlots(@PathVariable String meetingId) {
-        List<AvailableSlot> slots = meetingService.getFinalAvailableSlots(meetingId);
-        return ResponseEntity.ok(slots);
+    public ResponseEntity<List<AvailableSlot>> getAvailableSlots(
+        @PathVariable String meetingId,
+        @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        Meeting meeting = meetingService.findById(meetingId);
+        if (!meetingService.isParticipantOrHost(meeting, principal.getUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        return ResponseEntity.ok(meetingService.getFinalAvailableSlots(meetingId));
     }
 
     @GetMapping("/{meetingId}/daily-availability")
-    public ResponseEntity<Map<String, DailyCountDto>> getDailyAvailability(@PathVariable String meetingId) {
-        Map<String, DailyCountDto> dailyCounts = meetingService.getDailyAvailability(meetingId);
-        return ResponseEntity.ok(dailyCounts);
+    public ResponseEntity<Map<String, DailyCountDto>> getDailyAvailability(
+        @PathVariable String meetingId,
+        @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        Meeting meeting = meetingService.findById(meetingId);
+        if (!meetingService.isParticipantOrHost(meeting, principal.getUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        return ResponseEntity.ok(meetingService.getDailyAvailability(meetingId));
     }
 
     // -------------------------------------------------------------------------
@@ -165,13 +187,9 @@ public class MeetingController {
     @PostMapping("/join")
     public ResponseEntity<Meeting> joinByInviteCode(
         @AuthenticationPrincipal CustomPrincipal principal,
-        @RequestBody Map<String, String> body
+        @Valid @RequestBody JoinByInviteCodeRequest body
     ) {
-        String inviteCode = body.get("inviteCode");
-        if (inviteCode == null || inviteCode.isBlank()) {
-            return ResponseEntity.badRequest().build();
-        }
-        Meeting meeting = meetingService.joinByInviteCode(principal.getUserId(), inviteCode.trim());
+        Meeting meeting = meetingService.joinByInviteCode(principal.getUserId(), body.getInviteCode().trim());
         return ResponseEntity.ok(meeting);
     }
 

--- a/src/main/java/org/dallyeo/matuabom/meeting/domain/Meeting.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/domain/Meeting.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.mapping.Document;
 import java.time.Instant;
 import java.util.List;
@@ -37,4 +38,7 @@ public class Meeting {
 
     @Builder.Default
     private Instant createdAt = Instant.now();
+
+    @Version
+    private Long version;
 }

--- a/src/main/java/org/dallyeo/matuabom/meeting/domain/MeetingStatus.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/domain/MeetingStatus.java
@@ -1,0 +1,20 @@
+package org.dallyeo.matuabom.meeting.domain;
+
+/**
+ * 모임 상태 Enum.
+ * MongoDB 저장 시 문자열로 유지되므로 @Field 없이도 name()으로 직렬화됨.
+ */
+public enum MeetingStatus {
+    PENDING,    // 조율 중
+    CONFIRMED,  // 확정 완료
+    CLOSED;     // 종료/마감
+
+    public static MeetingStatus from(String value) {
+        if (value == null) return PENDING;
+        return switch (value.toUpperCase()) {
+            case "CONFIRMED" -> CONFIRMED;
+            case "CLOSED"    -> CLOSED;
+            default          -> PENDING;
+        };
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/meeting/dto/JoinByInviteCodeRequest.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/dto/JoinByInviteCodeRequest.java
@@ -1,0 +1,15 @@
+package org.dallyeo.matuabom.meeting.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class JoinByInviteCodeRequest {
+
+    @NotBlank(message = "초대 코드는 필수입니다.")
+    @Size(min = 8, max = 8, message = "초대 코드는 8자리여야 합니다.")
+    private String inviteCode;
+}

--- a/src/main/java/org/dallyeo/matuabom/meeting/service/AvailableTimeCalculator.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/service/AvailableTimeCalculator.java
@@ -124,6 +124,18 @@ public class AvailableTimeCalculator {
         MeetingParticipant participant,
         MeetingRequirement requirement
     ) {
+        return calculateFixedImpossibleSlots(participant, requirement, null, null);
+    }
+
+    /**
+     * 배치 처리용 오버로드 — 미리 조회한 캘린더/시간표 데이터를 파라미터로 받아 N+1 방지.
+     */
+    public List<ParticipantTimeStatus> calculateFixedImpossibleSlots(
+        MeetingParticipant participant,
+        MeetingRequirement requirement,
+        List<CalendarEventDto> preloadedCalendarEvents,
+        List<TimetableItem> preloadedTimetableItems
+    ) {
         String userId = participant.getUserId();
         boolean reflectCalendar = participant.isReflectCalendar();
         boolean reflectTimetable = participant.isReflectTimetable();
@@ -139,17 +151,24 @@ public class AvailableTimeCalculator {
 
         Map<LocalDate, Set<Integer>> impossibleSlotsMap = new HashMap<>();
 
-        // 제약 조건(시간대 범위) 밖의 슬롯을 먼저 불가능으로 마킹
         generateConstraintSchedules(candidateDates, requirement)
             .forEach(fs -> mapFixedScheduleToSlots(fs, impossibleSlotsMap));
 
         if (reflectCalendar) {
-            fetchAndNormalizeCalendarSchedules(userId, candidateDates)
+            List<CalendarEventDto> events = preloadedCalendarEvents != null
+                ? preloadedCalendarEvents
+                : calendarEventService.getEventsByUserId(userId,
+                    candidateDates.get(0).atStartOfDay(ZONE_SEOUL).toInstant().toEpochMilli(),
+                    candidateDates.get(candidateDates.size() - 1).plusDays(1).atStartOfDay(ZONE_SEOUL).toInstant().toEpochMilli());
+            normalizeCalendarSchedules(events, candidateDates)
                 .forEach(fs -> mapFixedScheduleToSlots(fs, impossibleSlotsMap));
         }
 
         if (reflectTimetable) {
-            fetchAndNormalizeTimetableSchedules(userId, candidateDates)
+            List<TimetableItem> items = preloadedTimetableItems != null
+                ? preloadedTimetableItems
+                : timetableService.getTimetableItems(userId);
+            normalizeTimetableSchedules(items, candidateDates)
                 .forEach(fs -> mapFixedScheduleToSlots(fs, impossibleSlotsMap));
         }
 
@@ -267,11 +286,17 @@ public class AvailableTimeCalculator {
     ) {
         LocalDate start = candidateDates.get(0);
         LocalDate end = candidateDates.get(candidateDates.size() - 1);
-
         long startTs = start.atStartOfDay(ZONE_SEOUL).toInstant().toEpochMilli();
         long endTs = end.plusDays(1).atStartOfDay(ZONE_SEOUL).toInstant().toEpochMilli();
-
         List<CalendarEventDto> events = calendarEventService.getEventsByUserId(userId, startTs, endTs);
+        return normalizeCalendarSchedules(events, candidateDates);
+    }
+
+    private List<FixedSchedule> normalizeCalendarSchedules(
+        List<CalendarEventDto> events,
+        List<LocalDate> candidateDates
+    ) {
+        LocalDate end = candidateDates.get(candidateDates.size() - 1);
         List<FixedSchedule> schedules = new ArrayList<>();
 
         for (CalendarEventDto event : events) {
@@ -315,6 +340,13 @@ public class AvailableTimeCalculator {
         List<LocalDate> candidateDates
     ) {
         List<TimetableItem> timetableItems = timetableService.getTimetableItems(userId);
+        return normalizeTimetableSchedules(timetableItems, candidateDates);
+    }
+
+    private List<FixedSchedule> normalizeTimetableSchedules(
+        List<TimetableItem> timetableItems,
+        List<LocalDate> candidateDates
+    ) {
         List<FixedSchedule> fixedSchedules = new ArrayList<>();
 
         for (TimetableItem item : timetableItems) {

--- a/src/main/java/org/dallyeo/matuabom/meeting/service/InviteCodeService.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/service/InviteCodeService.java
@@ -30,11 +30,13 @@ public class InviteCodeService {
     }
 
     private String generateUniqueCode(int length) {
-        while (true) {
+        int maxAttempts = 10;
+        for (int i = 0; i < maxAttempts; i++) {
             String code = inviteCodeGenerator.generateRandomCode(length);
             if (!inviteCodeJpaRepository.existsByCode(code)) {
                 return code;
             }
         }
+        throw new IllegalStateException("초대코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.");
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/meeting/service/MeetingService.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/service/MeetingService.java
@@ -12,6 +12,7 @@ import org.dallyeo.matuabom.calendar.service.GoogleCalendarService;
 import org.dallyeo.matuabom.calendar.repository.CalendarEventRepository;
 import org.dallyeo.matuabom.meeting.repository.MeetingRepository;
 import org.dallyeo.matuabom.user.repository.jpa.UserJpaRepository;
+import org.dallyeo.matuabom.timetable.domain.TimetableItem;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,8 @@ import java.security.GeneralSecurityException;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import java.security.SecureRandom;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -58,11 +61,8 @@ public class MeetingService {
             request.isDefaultReflectCalendar()
         );
 
-        // 호스트의 초기 불가능 슬롯 계산
-        participants.stream()
-            .filter(p -> p.getUserId().equals(hostUserId))
-            .findFirst()
-            .ifPresent(hostParticipant -> recalculateParticipantSchedules(hostParticipant, requirement));
+        // 전체 참여자 일정 배치 재계산 (N+1 방지)
+        recalculateAllParticipantSchedules(participants, requirement);
 
         String inviteCode = generateUniqueInviteCode();
 
@@ -89,6 +89,11 @@ public class MeetingService {
     public Meeting findById(String meetingId) {
         return meetingRepository.findById(meetingId)
             .orElseThrow(() -> new IllegalArgumentException("Meeting not found: " + meetingId));
+    }
+
+    public boolean isParticipantOrHost(Meeting meeting, String userId) {
+        if (userId.equals(meeting.getHostUserId())) return true;
+        return meeting.getParticipants().stream().anyMatch(p -> userId.equals(p.getUserId()));
     }
 
     // -------------------------------------------------------------------------
@@ -171,6 +176,13 @@ public class MeetingService {
             .collect(Collectors.toList());
 
         meeting.setParticipants(updatedParticipants);
+        // 새로 추가된 참여자 일정 배치 재계산
+        List<MeetingParticipant> newParticipants = updatedParticipants.stream()
+            .filter(p -> !oldParticipantMap.containsKey(p.getUserId()))
+            .collect(Collectors.toList());
+        if (!newParticipants.isEmpty()) {
+            recalculateAllParticipantSchedules(newParticipants, newRequirement);
+        }
         return meetingRepository.save(meeting);
     }
 
@@ -255,6 +267,8 @@ public class MeetingService {
         if (!meeting.getHostUserId().equals(hostUserId)) {
             throw new SecurityException("Only the host can delete the meeting.");
         }
+        // 모임에 연결된 CalendarEvent 고아 데이터 정리
+        calendarEventRepository.deleteByMeetingId(meetingId);
         meetingRepository.delete(meeting);
     }
 
@@ -427,9 +441,10 @@ public class MeetingService {
         }
 
         String newStatus = request.getStatus();
-        if (newStatus == null || !(newStatus.equals("PENDING")
-            || newStatus.equals("CONFIRMED")
-            || newStatus.equals("CLOSED"))) {
+        if (newStatus == null || MeetingStatus.from(newStatus) == null ||
+            !(newStatus.equals(MeetingStatus.PENDING.name())
+            || newStatus.equals(MeetingStatus.CONFIRMED.name())
+            || newStatus.equals(MeetingStatus.CLOSED.name()))) {
             throw new IllegalArgumentException("Invalid status: " + newStatus);
         }
 
@@ -450,26 +465,27 @@ public class MeetingService {
                     }
                     meeting.setConfirmedEnd(end);
                 } else {
-                    // 종일 설정: 하루 끝으로 설정
                     meeting.setConfirmedEnd(start.atZone(ZONE_SEOUL).toLocalDate()
                         .plusDays(1).atStartOfDay(ZONE_SEOUL).toInstant());
                 }
             } catch (DateTimeParseException e) {
                 throw new IllegalArgumentException("Invalid date format for confirmedStart/confirmedEnd", e);
             }
-
-            // 처음으로 CONFIRMED 되는 경우에만 캘린더 이벤트 생성
-            if (!"CONFIRMED".equals(oldStatus)) {
-                createConfirmedEventsForParticipants(meeting);
-            }
-
         } else if ("PENDING".equals(newStatus)) {
             meeting.setConfirmedStart(null);
             meeting.setConfirmedEnd(null);
         }
 
+        boolean shouldCreateEvents = "CONFIRMED".equals(newStatus) && !"CONFIRMED".equals(oldStatus);
         meeting.setStatus(newStatus);
-        return meetingRepository.save(meeting);
+        Meeting saved = meetingRepository.save(meeting);
+
+        // 캘린더 이벤트 생성은 트랜잭션 밖에서 실행 (외부 API 호출)
+        if (shouldCreateEvents) {
+            createConfirmedEventsForParticipants(saved);
+        }
+
+        return saved;
     }
 
     /**
@@ -525,15 +541,18 @@ public class MeetingService {
     // 내부 헬퍼
     // -------------------------------------------------------------------------
 
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private String generateUniqueInviteCode() {
         String chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-        Random random = new Random();
-        while (true) {
+        int maxAttempts = 10;
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
             StringBuilder sb = new StringBuilder(8);
-            for (int i = 0; i < 8; i++) sb.append(chars.charAt(random.nextInt(chars.length())));
+            for (int i = 0; i < 8; i++) sb.append(chars.charAt(SECURE_RANDOM.nextInt(chars.length())));
             String code = sb.toString();
             if (!meetingRepository.existsByInviteCode(code)) return code;
         }
+        throw new IllegalStateException("초대코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.");
     }
 
     // -------------------------------------------------------------------------
@@ -542,40 +561,88 @@ public class MeetingService {
 
     @Transactional
     public Meeting joinByInviteCode(String userId, String inviteCode) {
-        Meeting meeting = meetingRepository.findByInviteCode(inviteCode.toUpperCase())
-            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 초대 코드입니다."));
+        int maxRetries = 3;
+        for (int attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                Meeting meeting = meetingRepository.findByInviteCode(inviteCode.toUpperCase())
+                    .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 초대 코드입니다."));
 
-        if (!"PENDING".equals(meeting.getStatus())) {
-            throw new IllegalStateException("조율 중인 모임에만 참여할 수 있습니다.");
+                if (!"PENDING".equals(meeting.getStatus())) {
+                    throw new IllegalStateException("조율 중인 모임에만 참여할 수 있습니다.");
+                }
+
+                boolean alreadyJoined = meeting.getParticipants().stream()
+                    .anyMatch(p -> p.getUserId().equals(userId));
+                if (alreadyJoined) {
+                    throw new IllegalStateException("이미 참여한 모임입니다.");
+                }
+
+                UserEntity user = userRepository.findByMongoId(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+
+                MeetingParticipant newParticipant = new MeetingParticipant();
+                newParticipant.setUserId(userId);
+                newParticipant.setName(user.getNickname());
+                newParticipant.setStatus("ACCEPTED");
+                newParticipant.setTimeStatuses(new ArrayList<>());
+                newParticipant.setReflectTimetable(true);
+                newParticipant.setReflectCalendar(true);
+
+                meeting.getParticipants().add(newParticipant);
+                recalculateParticipantSchedules(newParticipant, meeting.getRequirement());
+                return meetingRepository.save(meeting);
+
+            } catch (OptimisticLockingFailureException e) {
+                if (attempt == maxRetries - 1) {
+                    throw new IllegalStateException("모임 참여 중 충돌이 발생했습니다. 다시 시도해주세요.");
+                }
+            }
         }
-
-        boolean alreadyJoined = meeting.getParticipants().stream()
-            .anyMatch(p -> p.getUserId().equals(userId));
-        if (alreadyJoined) {
-            throw new IllegalStateException("이미 참여한 모임입니다.");
-        }
-
-        UserEntity user = userRepository.findByMongoId(userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
-
-        MeetingParticipant newParticipant = new MeetingParticipant();
-        newParticipant.setUserId(userId);
-        newParticipant.setName(user.getNickname());
-        newParticipant.setStatus("ACCEPTED");
-        newParticipant.setTimeStatuses(new ArrayList<>());
-        newParticipant.setReflectTimetable(true);
-        newParticipant.setReflectCalendar(true);
-
-        meeting.getParticipants().add(newParticipant);
-        // 초대코드 참여 시에도 캘린더/시간표 반영
-        recalculateParticipantSchedules(newParticipant, meeting.getRequirement());
-        return meetingRepository.save(meeting);
+        throw new IllegalStateException("모임 참여에 실패했습니다.");
     }
 
     private void recalculateParticipantSchedules(MeetingParticipant participant, MeetingRequirement requirement) {
         List<ParticipantTimeStatus> fixedImpossibleStatuses =
             availableTimeCalculator.calculateFixedImpossibleSlots(participant, requirement);
         participant.setTimeStatuses(new ArrayList<>(fixedImpossibleStatuses));
+    }
+
+    /**
+     * 전체 참여자 일정 배치 재계산 — 캘린더/시간표를 userId 묶음으로 한 번씩만 조회하여 N+1 방지.
+     */
+    private void recalculateAllParticipantSchedules(List<MeetingParticipant> participants, MeetingRequirement requirement) {
+        if (participants == null || participants.isEmpty()) return;
+
+        List<LocalDate> candidateDates = availableTimeCalculator.expandDateRange(
+            requirement.getDateRangeStart(), requirement.getDateRangeEnd());
+        long startTs = candidateDates.get(0).atStartOfDay(ZONE_SEOUL).toInstant().toEpochMilli();
+        long endTs = candidateDates.get(candidateDates.size() - 1).plusDays(1).atStartOfDay(ZONE_SEOUL).toInstant().toEpochMilli();
+
+        List<String> calendarUserIds = participants.stream()
+            .filter(MeetingParticipant::isReflectCalendar)
+            .map(MeetingParticipant::getUserId)
+            .distinct()
+            .collect(Collectors.toList());
+
+        // 캘린더 이벤트 배치 조회 (N+1 방지)
+        Map<String, List<CalendarEventDto>> calendarMap = calendarUserIds.isEmpty()
+            ? Collections.emptyMap()
+            : calendarEventRepository
+                .findByUserIdInAndStartTimestampLessThanAndEndTimestampGreaterThan(calendarUserIds, endTs, startTs)
+                .stream()
+                .collect(Collectors.groupingBy(CalendarEventDto::getUserId));
+
+        for (MeetingParticipant participant : participants) {
+            List<CalendarEventDto> events = participant.isReflectCalendar()
+                ? calendarMap.getOrDefault(participant.getUserId(), Collections.emptyList())
+                : null;
+            // 시간표는 개인별 조회 (배치 미지원) — 향후 최적화 가능
+            List<TimetableItem> timetableItems = null;
+
+            List<ParticipantTimeStatus> fixed =
+                availableTimeCalculator.calculateFixedImpossibleSlots(participant, requirement, events, timetableItems);
+            participant.setTimeStatuses(new ArrayList<>(fixed));
+        }
     }
 
     private boolean isParticipantAvailableOnDate(MeetingParticipant participant, LocalDate date) {

--- a/src/main/java/org/dallyeo/matuabom/meeting/service/MeetingTimeSlotUtils.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/service/MeetingTimeSlotUtils.java
@@ -2,42 +2,36 @@ package org.dallyeo.matuabom.meeting.service;
 
 import org.dallyeo.matuabom.meeting.domain.ParticipantTimeStatus;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
+ * 모임 시간 슬롯 관련 유틸리티.
+ * 현재 AvailableTimeCalculator가 주요 로직을 담당하므로 이 클래스는 보조 역할만 합니다.
  */
 public class MeetingTimeSlotUtils {
 
-    private static final ZoneId ZONE_UTC = ZoneId.of("UTC");
+    private static final ZoneId ZONE_SEOUL = ZoneId.of("Asia/Seoul");
+
+    private MeetingTimeSlotUtils() {}
 
     /**
+     * 시작/종료 Instant 구간을 KST 기준 시간 슬롯(시 단위) Set으로 변환.
      */
     public static Set<Integer> convertRangeToSlots(Instant start, Instant end) {
         Set<Integer> slots = new HashSet<>();
 
-        ZonedDateTime zdtStart = start.atZone(ZONE_UTC);
-        ZonedDateTime zdtEnd = end.atZone(ZONE_UTC);
-
-        LocalDate date = zdtStart.toLocalDate();
-
+        ZonedDateTime zdtStart = start.atZone(ZONE_SEOUL);
+        ZonedDateTime zdtEnd = end.atZone(ZONE_SEOUL);
         ZonedDateTime current = zdtStart.withMinute(0).withSecond(0).withNano(0);
 
         while (current.isBefore(zdtEnd)) {
-            if (!current.toLocalDate().equals(date)) {
-            }
+            Instant slotStart = current.toInstant();
+            Instant slotEnd = current.plusHours(1).toInstant();
 
-            Instant slotStartInstant = current.toInstant();
-            Instant slotEndInstant = current.plusHours(1).toInstant();
-
-            if (slotStartInstant.isBefore(end) && slotEndInstant.isAfter(start)) {
+            if (slotStart.isBefore(end) && slotEnd.isAfter(start)) {
                 slots.add(current.getHour());
             }
-
             current = current.plusHours(1);
         }
 
@@ -45,20 +39,17 @@ public class MeetingTimeSlotUtils {
     }
 
     /**
+     * 날짜별 불가능 슬롯 Set을 ParticipantTimeStatus 리스트로 변환.
      */
-    public static List<ParticipantTimeStatus> convertSlotsToRanges(
-        LocalDate date,
-        Set<Integer> slots,
-        String status
+    public static List<ParticipantTimeStatus> convertToTimeStatuses(
+        Map<LocalDate, Set<Integer>> impossibleSlotsMap
     ) {
-        if (slots.isEmpty()) return Collections.emptyList();
-
-        List<Integer> sortedSlots = new ArrayList<>(slots);
-        Collections.sort(sortedSlots);
-
-        List<ParticipantTimeStatus> ranges = new ArrayList<>();
-
-
-        return ranges;
+        List<ParticipantTimeStatus> result = new ArrayList<>();
+        for (Map.Entry<LocalDate, Set<Integer>> entry : impossibleSlotsMap.entrySet()) {
+            if (!entry.getValue().isEmpty()) {
+                result.add(new ParticipantTimeStatus(entry.getKey(), entry.getValue()));
+            }
+        }
+        return result;
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/sse/service/EventSseService.java
+++ b/src/main/java/org/dallyeo/matuabom/sse/service/EventSseService.java
@@ -84,6 +84,26 @@ public class EventSseService {
         dead.forEach(e -> removeEmitter(userId, e));
     }
 
+    /**
+     * Google OAuth 토큰 갱신 실패 시 사용자에게 재연동 요청 알림.
+     */
+    public void sendGoogleReauthRequired(String userId) {
+        List<SseEmitter> emitters = userEmitters.getOrDefault(userId, List.of());
+        if (emitters.isEmpty()) {
+            log.warn("Google reauth required for userId={} but no SSE connection", userId);
+            return;
+        }
+        List<SseEmitter> dead = new ArrayList<>();
+        for (SseEmitter emitter : emitters) {
+            try {
+                emitter.send(SseEmitter.event().name("google-reauth-required").data("ok"));
+            } catch (IOException e) {
+                dead.add(emitter);
+            }
+        }
+        dead.forEach(e -> removeEmitter(userId, e));
+    }
+
     private void removeEmitter(String userId, SseEmitter emitter) {
         List<SseEmitter> list = userEmitters.get(userId);
         if (list != null) {

--- a/src/main/java/org/dallyeo/matuabom/stats/service/StatsService.java
+++ b/src/main/java/org/dallyeo/matuabom/stats/service/StatsService.java
@@ -11,12 +11,14 @@ import org.dallyeo.matuabom.stats.dto.TimeSlotStatDto;
 import org.dallyeo.matuabom.stats.dto.TopPartnerDto;
 import org.dallyeo.matuabom.meeting.repository.MeetingRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.*;
 import java.util.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StatsService {
 
     private final MeetingRepository meetingRepository;
@@ -61,12 +63,16 @@ public class StatsService {
     }
 
     public List<TopPartnerDto> getTopPartners(String userId, int limit) {
+        return getTopPartners(userId, limit, Instant.now());
+    }
+
+    public List<TopPartnerDto> getTopPartners(String userId, int limit, Instant now) {
         List<Meeting> meetings = meetingRepository.findByStatusOrStatusAndParticipantsUserId("CONFIRMED", "CLOSED", userId);
         Map<String, PartnerCounter> countingMap = new HashMap<>();
 
         for (Meeting meeting : meetings) {
             if (meeting.getParticipants() == null || meeting.getConfirmedStart() == null) continue;
-            if (meeting.getConfirmedStart().isAfter(Instant.now())) continue;
+            if (meeting.getConfirmedStart().isAfter(now)) continue;
             if (!isAccepted(meeting, userId)) continue;
 
             for (MeetingParticipant participant : meeting.getParticipants()) {

--- a/src/main/java/org/dallyeo/matuabom/user/repository/jpa/FriendJpaRepository.java
+++ b/src/main/java/org/dallyeo/matuabom/user/repository/jpa/FriendJpaRepository.java
@@ -16,4 +16,6 @@ public interface FriendJpaRepository extends JpaRepository<FriendEntity, Long> {
     List<FriendEntity> findAllByUserId(@Param("userId") String userId);
 
     Optional<FriendEntity> findByUserId1AndUserId2(String userId1, String userId2);
+
+    void deleteAllByUserId1OrUserId2(String userId1, String userId2);
 }

--- a/src/main/java/org/dallyeo/matuabom/user/service/FriendService.java
+++ b/src/main/java/org/dallyeo/matuabom/user/service/FriendService.java
@@ -96,5 +96,9 @@ public class FriendService {
                 .orElseThrow(() -> new IllegalArgumentException("친구가 아닙니다."));
 
         friendJpaRepository.delete(relation);
+
+        // [정책] 친구 삭제 시 기존 모임의 MeetingParticipant 데이터는 유지됩니다.
+        // 이미 확정(CONFIRMED)되거나 진행 중인 모임의 참여 이력을 보존하는 것이 의도된 동작입니다.
+        // 모임에서도 해당 사용자를 제거하려면 모임 호스트가 직접 모임을 수정해야 합니다.
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/user/service/UserService.java
+++ b/src/main/java/org/dallyeo/matuabom/user/service/UserService.java
@@ -2,19 +2,22 @@ package org.dallyeo.matuabom.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.dallyeo.matuabom.auth.dto.UpsertKakaoUserDto;
+import org.dallyeo.matuabom.meeting.domain.Meeting;
+import org.dallyeo.matuabom.meeting.repository.MeetingRepository;
 import org.dallyeo.matuabom.user.domain.UserEntity;
 import org.dallyeo.matuabom.user.repository.jpa.UserJpaRepository;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserJpaRepository userJpaRepository;
+    private final MeetingRepository meetingRepository;
 
     public UserEntity findById(String userId) {
         // userId는 mongoId(문자열) 기준으로 조회 (마이그레이션 기간 동안 호환)
@@ -30,10 +33,15 @@ public class UserService {
     public String upsertKakaoUser(UpsertKakaoUserDto dto) {
         UserEntity user = userJpaRepository.findByKakaoId(dto.getKakaoId())
                 .map(u -> {
+                    String oldNickname = u.getNickname();
                     u.setNickname(dto.getNickname());
                     u.setProfileImageUrl(dto.getProfileImageUrl());
-                    // OAuth 토큰은 User 엔티티에서 제거 — 필요 시 별도 암호화 저장소 사용
-                    return userJpaRepository.save(u);
+                    UserEntity saved = userJpaRepository.save(u);
+                    // 닉네임이 변경된 경우 Meeting 참여자 이름도 동기화
+                    if (!dto.getNickname().equals(oldNickname) && saved.getMongoId() != null) {
+                        syncParticipantNames(saved.getMongoId(), dto.getNickname());
+                    }
+                    return saved;
                 })
                 .orElseGet(() -> {
                     UserEntity newUser = UserEntity.builder()
@@ -63,5 +71,24 @@ public class UserService {
         return userJpaRepository.findByMongoId(userId)
                 .map(UserEntity::getGoogleEmail)
                 .orElse(null);
+    }
+
+    /**
+     * 닉네임 변경 시 PENDING/CONFIRMED 모임의 참여자 이름 동기화.
+     */
+    private void syncParticipantNames(String userId, String newNickname) {
+        List<Meeting> meetings = meetingRepository
+                .findAllByHostUserIdOrParticipantsUserId(userId, userId);
+        for (Meeting meeting : meetings) {
+            boolean changed = false;
+            for (var participant : meeting.getParticipants()) {
+                if (userId.equals(participant.getUserId())
+                        && !newNickname.equals(participant.getName())) {
+                    participant.setName(newNickname);
+                    changed = true;
+                }
+            }
+            if (changed) meetingRepository.save(meeting);
+        }
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/user/service/UserWithdrawalService.java
+++ b/src/main/java/org/dallyeo/matuabom/user/service/UserWithdrawalService.java
@@ -1,0 +1,84 @@
+package org.dallyeo.matuabom.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dallyeo.matuabom.auth.service.TokenStore;
+import org.dallyeo.matuabom.calendar.repository.CalendarEventRepository;
+import org.dallyeo.matuabom.calendar.repository.GoogleOAuthClientRepository;
+import org.dallyeo.matuabom.meeting.domain.Meeting;
+import org.dallyeo.matuabom.meeting.repository.MeetingRepository;
+import org.dallyeo.matuabom.user.repository.jpa.FriendJpaRepository;
+import org.dallyeo.matuabom.user.repository.jpa.UserJpaRepository;
+import org.dallyeo.matuabom.user.repository.mongo.UserMongoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserWithdrawalService {
+
+    private final UserMongoRepository userMongoRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final FriendJpaRepository friendJpaRepository;
+    private final GoogleOAuthClientRepository googleOAuthClientRepository;
+    private final CalendarEventRepository calendarEventRepository;
+    private final MeetingRepository meetingRepository;
+    private final TokenStore tokenStore;
+
+    /**
+     * 회원 탈퇴 처리.
+     * - 호스트인 모임은 삭제
+     * - 참여자인 모임은 참여자 목록에서 제거
+     * - PostgreSQL: UserEntity, FriendEntity 삭제
+     * - MongoDB: User, GoogleOAuthClientEntity, CalendarEventDto 삭제
+     * - Redis: Refresh Token 삭제
+     */
+    @Transactional
+    public void withdraw(String userId, String accessToken) {
+        log.info("User withdrawal initiated: userId={}", userId);
+
+        // 1. 모임 처리: 호스트면 삭제, 참여자면 목록에서 제거
+        processUserMeetings(userId);
+
+        // 2. 캘린더 이벤트 삭제 (MongoDB)
+        calendarEventRepository.deleteByUserId(userId);
+
+        // 3. Google OAuth 토큰 삭제 (MongoDB)
+        googleOAuthClientRepository.deleteByUserId(userId);
+
+        // 4. 친구 관계 삭제 (PostgreSQL)
+        friendJpaRepository.deleteAllByUserId1OrUserId2(userId, userId);
+
+        // 5. PostgreSQL UserEntity 삭제
+        userJpaRepository.findByMongoId(userId)
+                .ifPresent(userJpaRepository::delete);
+
+        // 6. MongoDB User 삭제
+        userMongoRepository.deleteById(userId);
+
+        // 7. Redis: Refresh Token 삭제
+        tokenStore.deleteRefreshToken(userId);
+
+        log.info("User withdrawal completed: userId={}", userId);
+    }
+
+    private void processUserMeetings(String userId) {
+        List<Meeting> meetings = meetingRepository
+                .findAllByHostUserIdOrParticipantsUserId(userId, userId);
+
+        for (Meeting meeting : meetings) {
+            if (userId.equals(meeting.getHostUserId())) {
+                // 호스트인 경우: 관련 CalendarEvent 삭제 후 모임 삭제
+                calendarEventRepository.deleteByMeetingId(meeting.getId());
+                meetingRepository.delete(meeting);
+            } else {
+                // 참여자인 경우: 참여자 목록에서 제거
+                meeting.getParticipants().removeIf(p -> userId.equals(p.getUserId()));
+                meetingRepository.save(meeting);
+            }
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,15 @@
+# 개발 환경 전용 설정
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+app:
+  cookie-secure: false
+
+logging:
+  level:
+    root: INFO
+    org.dallyeo.matuabom: DEBUG
+    org.springframework.security: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,22 @@
+# 운영 환경 전용 설정
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+
+app:
+  cookie-secure: true
+
+# 운영에서 Swagger UI 비활성화
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
+logging:
+  level:
+    root: WARN
+    org.dallyeo.matuabom: INFO
+    org.springframework.security: WARN

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update          # 운영: validate / 개발 초기: update
+      ddl-auto: ${DDL_AUTO:update}   # dev: update / prod: validate (application-prod.yml에서 override)
     show-sql: false
     properties:
       hibernate:
@@ -68,7 +68,6 @@ spring:
             scope:
               - profile_nickname
               - profile_image
-              - friends
             client-authentication-method: client_secret_post
             provider: kakao
 
@@ -96,6 +95,8 @@ app:
   backend-base-url: ${BACKEND_BASE_URL:http://localhost:8080}
   cookie-secure: ${COOKIE_SECURE:false}
   admin-secret: ${ADMIN_SECRET:admin1234}
+  encrypt-key: ${ENCRYPT_KEY:}  # 누락 시 AesEncryptor 내부 개발용 기본키 사용 (운영은 반드시 설정)
+  google-webhook-token: ${GOOGLE_WEBHOOK_TOKEN:}
   jwt:
     access-token-seconds: 7200        # 2시간
     refresh-token-seconds: 2592000    # 30일
@@ -116,3 +117,9 @@ management:
       enabled: true
     readinessState:
       enabled: true
+    db:
+      enabled: true     # PostgreSQL 연결 확인
+    mongo:
+      enabled: true     # MongoDB 연결 확인
+    redis:
+      enabled: true     # Redis 연결 확인

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 콘솔 appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일 appender (날짜별 로테이션) -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/matuabom.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/matuabom.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>2GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 비동기 파일 appender (I/O 블로킹 방지) -->
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <appender-ref ref="FILE"/>
+    </appender>
+
+    <!-- 개발 환경 -->
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="org.dallyeo.matuabom" level="DEBUG"/>
+        <logger name="org.springframework.security" level="DEBUG"/>
+    </springProfile>
+
+    <!-- 운영 환경 -->
+    <springProfile name="prod">
+        <root level="WARN">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+        <logger name="org.dallyeo.matuabom" level="INFO"/>
+        <!-- 민감 정보 노출 방지: security 로그 WARN 이상만 -->
+        <logger name="org.springframework.security" level="WARN"/>
+    </springProfile>
+
+    <!-- 기본 (프로파일 미지정) -->
+    <springProfile name="!dev &amp; !prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="org.dallyeo.matuabom" level="DEBUG"/>
+    </springProfile>
+
+</configuration>

--- a/src/test/java/org/dallyeo/matuabom/common/crypto/AesEncryptorTest.java
+++ b/src/test/java/org/dallyeo/matuabom/common/crypto/AesEncryptorTest.java
@@ -1,0 +1,61 @@
+package org.dallyeo.matuabom.common.crypto;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.*;
+
+class AesEncryptorTest {
+
+    private AesEncryptor encryptor;
+
+    @BeforeEach
+    void setUp() {
+        // 정확히 32바이트인 Base64 키 (matuabom-dev-only-key-32bytes!!!)
+        String key = Base64.getEncoder().encodeToString("matuabom-dev-only-key-32bytes!!!".getBytes());
+        encryptor = new AesEncryptor(key);
+    }
+
+    @Test
+    @DisplayName("암호화 후 복호화하면 원문과 동일해야 함")
+    void encryptDecryptRoundTrip() {
+        String plainText = "test-refresh-token-value";
+
+        String encrypted = encryptor.encrypt(plainText);
+        String decrypted = encryptor.decrypt(encrypted);
+
+        assertThat(decrypted).isEqualTo(plainText);
+    }
+
+    @Test
+    @DisplayName("암호화 결과는 원문과 달라야 함")
+    void encryptedDiffersFromPlainText() {
+        String plainText = "secret-token";
+        String encrypted = encryptor.encrypt(plainText);
+
+        assertThat(encrypted).isNotEqualTo(plainText);
+    }
+
+    @Test
+    @DisplayName("같은 원문이라도 암호화할 때마다 다른 값 (IV가 랜덤)")
+    void sameInputProducesDifferentCiphertext() {
+        String plainText = "same-token";
+        String enc1 = encryptor.encrypt(plainText);
+        String enc2 = encryptor.encrypt(plainText);
+
+        assertThat(enc1).isNotEqualTo(enc2);
+        // 하지만 복호화 결과는 같아야 함
+        assertThat(encryptor.decrypt(enc1)).isEqualTo(plainText);
+        assertThat(encryptor.decrypt(enc2)).isEqualTo(plainText);
+    }
+
+    @Test
+    @DisplayName("null 입력 시 null 반환")
+    void nullInputReturnsNull() {
+        assertThat(encryptor.encrypt(null)).isNull();
+        assertThat(encryptor.decrypt(null)).isNull();
+    }
+}

--- a/src/test/java/org/dallyeo/matuabom/global/util/JwtUtilTest.java
+++ b/src/test/java/org/dallyeo/matuabom/global/util/JwtUtilTest.java
@@ -1,0 +1,70 @@
+package org.dallyeo.matuabom.global.util;
+
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class JwtUtilTest {
+
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        // 32자 이상의 테스트용 시크릿
+        jwtUtil = new JwtUtil(
+            "test-secret-key-minimum-32-characters-long!!",
+            3600L,
+            86400L
+        );
+    }
+
+    @Test
+    @DisplayName("Access Token 생성 및 검증")
+    void createAndValidateAccessToken() {
+        String token = jwtUtil.createAccessToken("user123");
+
+        String userId = jwtUtil.validateAndGetSub(token);
+        String type = jwtUtil.getTokenType(token);
+
+        assertThat(userId).isEqualTo("user123");
+        assertThat(type).isEqualTo("access");
+    }
+
+    @Test
+    @DisplayName("Refresh Token 생성 및 검증")
+    void createAndValidateRefreshToken() {
+        String token = jwtUtil.createRefreshToken("user456");
+
+        String userId = jwtUtil.validateAndGetSub(token);
+        String type = jwtUtil.getTokenType(token);
+
+        assertThat(userId).isEqualTo("user456");
+        assertThat(type).isEqualTo("refresh");
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰은 JwtException 발생")
+    void invalidTokenThrowsException() {
+        assertThatThrownBy(() -> jwtUtil.validateAndGetSub("invalid.token.value"))
+            .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("jti는 토큰마다 고유해야 함")
+    void jtiIsUniquePerToken() {
+        String token1 = jwtUtil.createAccessToken("user1");
+        String token2 = jwtUtil.createAccessToken("user1");
+
+        assertThat(jwtUtil.getJti(token1)).isNotEqualTo(jwtUtil.getJti(token2));
+    }
+
+    @Test
+    @DisplayName("만료 시각이 현재 이후여야 함")
+    void expirationIsInFuture() {
+        String token = jwtUtil.createAccessToken("user1");
+        assertThat(jwtUtil.getExpiration(token)).isAfter(java.time.Instant.now());
+    }
+}

--- a/src/test/java/org/dallyeo/matuabom/meeting/service/AvailableTimeCalculatorTest.java
+++ b/src/test/java/org/dallyeo/matuabom/meeting/service/AvailableTimeCalculatorTest.java
@@ -1,0 +1,97 @@
+package org.dallyeo.matuabom.meeting.service;
+
+import org.dallyeo.matuabom.meeting.domain.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class AvailableTimeCalculatorTest {
+
+    @Mock
+    private org.dallyeo.matuabom.calendar.service.CalendarEventService calendarEventService;
+    @Mock
+    private org.dallyeo.matuabom.timetable.service.TimetableService timetableService;
+
+    @InjectMocks
+    private AvailableTimeCalculator calculator;
+
+    private MeetingRequirement allDayRequirement(int days) {
+        Instant start = LocalDate.now().atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
+        Instant end = LocalDate.now().plusDays(days).atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
+        return MeetingRequirement.builder()
+            .dateRangeStart(start)
+            .dateRangeEnd(end)
+            .isAllDay(true)
+            .timeConstraints(Collections.emptyList())
+            .build();
+    }
+
+    @Test
+    @DisplayName("참여자가 없으면 공통 가용 슬롯은 빈 리스트")
+    void noParticipantsReturnsEmpty() {
+        List<AvailableSlot> result = calculator.findCommonAvailableSlots(Collections.emptyList());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("reflectCalendar=false, reflectTimetable=false 이면 불가 슬롯 없음")
+    void noReflectMeansNoImpossibleSlots() {
+        MeetingParticipant participant = new MeetingParticipant();
+        participant.setUserId("user1");
+        participant.setReflectCalendar(false);
+        participant.setReflectTimetable(false);
+
+        List<ParticipantTimeStatus> result = calculator.calculateFixedImpossibleSlots(
+            participant, allDayRequirement(3));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("날짜 범위 확장 - 3일 범위는 3개의 날짜 반환")
+    void expandDateRangeReturnsCorrectCount() {
+        Instant start = LocalDate.of(2025, 1, 1).atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
+        Instant end = LocalDate.of(2025, 1, 3).atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
+
+        List<LocalDate> dates = calculator.expandDateRange(start, end);
+
+        assertThat(dates).hasSize(3);
+        assertThat(dates.get(0)).isEqualTo(LocalDate.of(2025, 1, 1));
+        assertThat(dates.get(2)).isEqualTo(LocalDate.of(2025, 1, 3));
+    }
+
+    @Test
+    @DisplayName("모든 참여자가 특정 시간대가 불가능하면 공통 슬롯에서 제외")
+    void commonSlotExcludesImpossibleHours() {
+        ParticipantTimeStatus status = new ParticipantTimeStatus(
+            LocalDate.now(), new HashSet<>(Set.of(9, 10, 11)));
+
+        MeetingParticipant p1 = new MeetingParticipant();
+        p1.setUserId("user1");
+        p1.setTimeStatuses(List.of(status));
+
+        MeetingParticipant p2 = new MeetingParticipant();
+        p2.setUserId("user2");
+        p2.setTimeStatuses(List.of(
+            new ParticipantTimeStatus(LocalDate.now(), new HashSet<>(Set.of(9, 10, 11)))));
+
+        List<AvailableSlot> slots = calculator.findCommonAvailableSlots(List.of(p1, p2));
+
+        // 9, 10, 11시는 모두 불가 → 해당 시간대 슬롯 없어야 함
+        ZoneId seoul = ZoneId.of("Asia/Seoul");
+        boolean has9am = slots.stream().anyMatch(s -> {
+            LocalTime t = s.getStart().atZone(seoul).toLocalTime();
+            return t.getHour() == 9;
+        });
+        assertThat(has9am).isFalse();
+    }
+}

--- a/src/test/java/org/dallyeo/matuabom/meeting/service/MeetingServiceInviteCodeTest.java
+++ b/src/test/java/org/dallyeo/matuabom/meeting/service/MeetingServiceInviteCodeTest.java
@@ -1,0 +1,122 @@
+package org.dallyeo.matuabom.meeting.service;
+
+import org.dallyeo.matuabom.calendar.repository.CalendarEventRepository;
+import org.dallyeo.matuabom.calendar.repository.CalendarEventRepository;
+import org.dallyeo.matuabom.meeting.domain.*;
+import org.dallyeo.matuabom.meeting.repository.MeetingRepository;
+import org.dallyeo.matuabom.auth.service.GoogleOAuthClientService;
+import org.dallyeo.matuabom.calendar.service.GoogleCalendarService;
+import org.dallyeo.matuabom.user.domain.UserEntity;
+import org.dallyeo.matuabom.user.repository.jpa.UserJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingServiceInviteCodeTest {
+
+    @Mock MeetingRepository meetingRepository;
+    @Mock UserJpaRepository userRepository;
+    @Mock AvailableTimeCalculator availableTimeCalculator;
+    @Mock GoogleOAuthClientService googleOAuthClientService;
+    @Mock GoogleCalendarService googleCalendarService;
+    @Mock CalendarEventRepository calendarEventRepository;
+
+    @InjectMocks MeetingService meetingService;
+
+    private Meeting testMeeting;
+    private UserEntity testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = UserEntity.builder()
+            .id(1L)
+            .mongoId("user123")
+            .nickname("테스트유저")
+            .build();
+
+        MeetingRequirement requirement = MeetingRequirement.builder()
+            .dateRangeStart(Instant.now())
+            .dateRangeEnd(Instant.now().plusSeconds(86400 * 7))
+            .isAllDay(true)
+            .timeConstraints(List.of())
+            .build();
+
+        testMeeting = Meeting.builder()
+            .id("meeting123")
+            .hostUserId("host456")
+            .name("테스트 모임")
+            .status("PENDING")
+            .inviteCode("ABCD1234")
+            .requirement(requirement)
+            .participants(new ArrayList<>())
+            .build();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 초대코드로 참여 시 예외 발생")
+    void joinWithInvalidCode() {
+        given(meetingRepository.findByInviteCode(anyString())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> meetingService.joinByInviteCode("user123", "INVALID1"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("유효하지 않은 초대 코드");
+    }
+
+    @Test
+    @DisplayName("CONFIRMED 모임은 참여 불가")
+    void cannotJoinConfirmedMeeting() {
+        testMeeting.setStatus("CONFIRMED");
+        given(meetingRepository.findByInviteCode("ABCD1234")).willReturn(Optional.of(testMeeting));
+
+        assertThatThrownBy(() -> meetingService.joinByInviteCode("user123", "ABCD1234"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("조율 중인 모임");
+    }
+
+    @Test
+    @DisplayName("이미 참여한 모임에 재참여 시 예외 발생")
+    void cannotJoinAlreadyJoinedMeeting() {
+        MeetingParticipant existing = new MeetingParticipant();
+        existing.setUserId("user123");
+        testMeeting.getParticipants().add(existing);
+
+        given(meetingRepository.findByInviteCode("ABCD1234")).willReturn(Optional.of(testMeeting));
+
+        assertThatThrownBy(() -> meetingService.joinByInviteCode("user123", "ABCD1234"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("이미 참여");
+    }
+
+    @Test
+    @DisplayName("정상 참여 시 참여자 목록에 추가됨")
+    void joinSuccessfully() {
+        given(meetingRepository.findByInviteCode("ABCD1234")).willReturn(Optional.of(testMeeting));
+        given(userRepository.findByMongoId("user123")).willReturn(Optional.of(testUser));
+        given(availableTimeCalculator.expandDateRange(any(), any())).willReturn(List.of(java.time.LocalDate.now()));
+        given(calendarEventRepository.findByUserIdInAndStartTimestampLessThanAndEndTimestampGreaterThan(any(), anyLong(), anyLong()))
+            .willReturn(List.of());
+        given(availableTimeCalculator.calculateFixedImpossibleSlots(any(), any(), any(), any()))
+            .willReturn(List.of());
+        given(meetingRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        Meeting result = meetingService.joinByInviteCode("user123", "ABCD1234");
+
+        assertThat(result.getParticipants()).hasSize(1);
+        assertThat(result.getParticipants().get(0).getUserId()).isEqualTo("user123");
+        assertThat(result.getParticipants().get(0).getName()).isEqualTo("테스트유저");
+    }
+}

--- a/src/test/java/org/dallyeo/matuabom/user/service/FriendServiceTest.java
+++ b/src/test/java/org/dallyeo/matuabom/user/service/FriendServiceTest.java
@@ -1,0 +1,81 @@
+package org.dallyeo.matuabom.user.service;
+
+import org.dallyeo.matuabom.auth.service.TokenStore;
+import org.dallyeo.matuabom.user.domain.FriendEntity;
+import org.dallyeo.matuabom.user.domain.InviteCodeEntity;
+import org.dallyeo.matuabom.user.domain.UserEntity;
+import org.dallyeo.matuabom.user.repository.jpa.FriendJpaRepository;
+import org.dallyeo.matuabom.user.repository.jpa.InviteCodeJpaRepository;
+import org.dallyeo.matuabom.user.repository.jpa.UserJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FriendServiceTest {
+
+    @Mock FriendJpaRepository friendJpaRepository;
+    @Mock InviteCodeJpaRepository inviteCodeJpaRepository;
+    @Mock UserJpaRepository userJpaRepository;
+    @Mock TokenStore tokenStore;
+
+    @InjectMocks FriendService friendService;
+
+    @Test
+    @DisplayName("자신의 초대코드로는 친구 추가 불가")
+    void cannotAddSelfAsFriend() {
+        given(tokenStore.getCachedInviteOwner("MYCODE")).willReturn("user123");
+
+        assertThatThrownBy(() -> friendService.addFriend("user123", "MYCODE"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("자신의 초대코드");
+    }
+
+    @Test
+    @DisplayName("이미 친구인 경우 중복 추가 불가")
+    void cannotAddDuplicateFriend() {
+        given(tokenStore.getCachedInviteOwner("CODE1")).willReturn("user456");
+        given(friendJpaRepository.existsByUserId1AndUserId2(any(), any())).willReturn(true);
+
+        assertThatThrownBy(() -> friendService.addFriend("user123", "CODE1"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("이미 친구");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 초대코드 사용 시 예외")
+    void invalidInviteCodeThrowsException() {
+        given(tokenStore.getCachedInviteOwner("INVALID")).willReturn(null);
+        given(inviteCodeJpaRepository.findByCode("INVALID")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> friendService.addFriend("user123", "INVALID"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("초대코드");
+    }
+
+    @Test
+    @DisplayName("정상적인 친구 추가")
+    void addFriendSuccessfully() {
+        UserEntity targetUser = UserEntity.builder()
+            .id(2L).mongoId("user456").nickname("친구유저").build();
+
+        given(tokenStore.getCachedInviteOwner("CODE2")).willReturn("user456");
+        given(friendJpaRepository.existsByUserId1AndUserId2(any(), any())).willReturn(false);
+        given(friendJpaRepository.save(any())).willReturn(new FriendEntity());
+        given(userJpaRepository.findByMongoId("user456")).willReturn(Optional.of(targetUser));
+
+        UserEntity result = friendService.addFriend("user123", "CODE2");
+
+        assertThat(result.getNickname()).isEqualTo("친구유저");
+        then(friendJpaRepository).should().save(any());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,48 @@
+spring:
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/matuabom_test
+      database: matuabom_test
+    redis:
+      host: localhost
+      port: 6379
+      password:
+
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+JWT_SECRET: test-secret-key-minimum-32-characters-long
+ENCRYPT_KEY:
+
+app:
+  jwt:
+    access-token-seconds: 3600
+    refresh-token-seconds: 86400
+  cookie-secure: false
+  encrypt-key:
+  google-webhook-token:
+  frontend-base-url: http://localhost:3000
+  backend-base-url: http://localhost:8080
+  admin-secret: test-admin
+
+GOOGLE_CLIENT_ID: test-google-client-id
+GOOGLE_CLIENT_SECRET: test-google-client-secret
+KAKAO_CLIENT_ID: test-kakao-client-id
+KAKAO_CLIENT_SECRET: test-kakao-client-secret
+GEMINI_API_KEY: test-gemini-key
+
+logging:
+  level:
+    root: WARN
+    org.dallyeo.matuabom: INFO


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #66 

## 📝 작업 내용
Google OAuth Refresh Token AES-256-GCM 암호화 저장 (AesEncryptor, MongoConfig Converter 등록)
/terms 이용약관 페이지 생성
DELETE /api/auth/me 회원 탈퇴 API 구현 (PostgreSQL, MongoDB, Redis 전체 데이터 삭제)
RateLimitFilter 추가 — IP 기반 엔드포인트별 Rate Limiting (Bucket4j)


> 작업내용 설명

### ✨ 스크린샷

### 💬 리뷰 요구사항
