### PR TITLE
Reduce Google Calendar OAuth scope to calendar.events

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ spring:
               - openid
               - profile
               - email
-              - https://www.googleapis.com/auth/calendar
+              - https://www.googleapis.com/auth/calendar.events
 
           kakao:
             client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## Summary
- Replaces the broad Google Calendar OAuth scope with the narrower https://www.googleapis.com/auth/calendar.events scope.
- Keeps OpenID/profile/email scopes unchanged.

## Why
The app only calls Google Calendar Events APIs on the user's primary calendar: list, insert, get, update, delete, and watch. It does not manage calendar sharing, ACLs, calendar lists, secondary calendars, or calendar deletion, so the full https://www.googleapis.com/auth/calendar scope is broader than necessary.

Closes #88

## Verification
- ./gradlew.bat clean bootJar -x test passes.
- ./gradlew.bat test currently fails in pre-existing tests unrelated to this scope-only config change:
  - FriendServiceTest: expected legacy exception types differ from current ConflictException/NotFoundException.
  - MeetingServiceInviteCodeTest: expected legacy exception type and Mockito strict stubbing mismatch.
  - MatuabomApplicationTests.contextLoads: ApplicationContext load failure in test profile.
