### PR TITLE
fix : admin-secret 기본값 admin1234 제거 (#90)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,7 +89,7 @@ app:
   frontend-base-url: ${FRONTEND_ORIGIN:http://localhost:3000}
   backend-base-url: ${BACKEND_BASE_URL:http://localhost:8080}
   cookie-secure: ${COOKIE_SECURE:false}
-  admin-secret: ${ADMIN_SECRET:admin1234}
+  admin-secret: ${ADMIN_SECRET}
   encrypt-key: ${ENCRYPT_KEY:}  # 누락 시 AesEncryptor 내부 개발용 기본키 사용 (운영은 반드시 설정)
   google-webhook-token: ${GOOGLE_WEBHOOK_TOKEN:}
   jwt:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #90

## 📝 작업 내용
> application.yml의 admin-secret 기본값 admin1234 제거

Public 레포에 기본값이 노출되어 있어, ADMIN_SECRET 환경변수 미설정 시 누구나 관리자 API 접근 가능한 보안 취약점을 수정한다.

변경 전: admin-secret: ${ADMIN_SECRET:admin1234}
변경 후: admin-secret: ${ADMIN_SECRET} (환경변수 필수, 미설정 시 기동 실패)

### ✨ 스크린샷

### 💬 리뷰 요구사항

Closes #90