### PR TITLE
fix : 모임 확정 캘린더 이벤트 날짜 오늘로 저장되는 버그 수정 (#92)

### DIFF
--- a/src/main/java/org/dallyeo/matuabom/meeting/service/MeetingService.java
+++ b/src/main/java/org/dallyeo/matuabom/meeting/service/MeetingService.java
@@ -547,13 +547,17 @@ public class MeetingService {
 
         ZonedDateTime startZdt = start.atZone(ZONE_SEOUL);
         ZonedDateTime endZdt = end.atZone(ZONE_SEOUL);
-        String startStr = startZdt.toOffsetDateTime().toString();
-        String endStr = endZdt.toOffsetDateTime().toString();
 
         // 종일 여부: 시작이 자정이고 종료가 다음날 자정인 경우
         boolean isAllDay = startZdt.toLocalTime().equals(java.time.LocalTime.MIDNIGHT)
             && endZdt.toLocalTime().equals(java.time.LocalTime.MIDNIGHT)
             && !startZdt.toLocalDate().equals(endZdt.toLocalDate());
+
+        // 종일이면 날짜 문자열("yyyy-MM-dd"), 비종일이면 UTC ISO 문자열("yyyy-MM-dd'T'HH:mm:ss'Z'")을 사용
+        // toOffsetDateTime().toString()은 초를 생략("HH:mm+09:00")할 수 있어 createLocalEvent/buildGoogleEvent의
+        // looksLikeDateOnly() 판별 실패 → LocalDate.now() fallback으로 오늘 날짜로 저장되는 버그 방지
+        String startStr = isAllDay ? startZdt.toLocalDate().toString() : start.toString();
+        String endStr   = isAllDay ? endZdt.toLocalDate().toString()   : end.toString();
 
         for (MeetingParticipant participant : meeting.getParticipants()) {
             if (!"ACCEPTED".equals(participant.getStatus())) continue;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #92

## 📝 작업 내용
> 모임 확정(CONFIRMED) 시 캘린더에 생성되는 이벤트 날짜가 확정 날짜가 아닌 오늘 날짜로 저장되던 버그를 수정합니다.
>
> **원인:** `toOffsetDateTime().toString()`이 초가 0일 때 `'HH:mm+09:00'`(초 생략) 형태를 반환하여,
> `createLocalEvent` / `buildGoogleEvent`의 allDay 경로에서 `looksLikeDateOnly()` = false → `LocalDate.now()` fallback으로 오늘 날짜가 사용됨.
>
> **수정:** 종일 이벤트는 `'yyyy-MM-dd'`(날짜 전용), 비종일은 `start.toString()`(UTC ISO `'Z'` suffix)으로 변경하여 항상 올바르게 파싱되도록 합니다.

### ✨ 스크린샷

### 💬 리뷰 요구사항
- 모임 확정 후 캘린더 이벤트가 확정 날짜에 정상 생성되는지 확인
- 종일 모임 확정 시에도 정상 동작하는지 확인

Closes #92