### PR TITLE
fix : refresh 토큰 회전 race로 인한 주기적 로그아웃 수정 (#97)

### DIFF
--- a/src/main/java/org/dallyeo/matuabom/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/filter/JwtAuthFilter.java
@@ -91,71 +91,52 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 // ── 분산 락 획득 ───────────────────────────────────────────
                 if (tokenStore.acquireTokenRefreshLock(userId)) {
                     try {
-                        // 1. 명시적 폐기(로그아웃) 확인 — rf_blacklist에 있으면 차단
-                        if (tokenStore.isRefreshBlacklistedSafe(refreshJti)) {
-                            log.warn("Blacklisted refresh token used. userId={}", userId);
-                            clearContext(response);
-                            filterChain.doFilter(request, response);
-                            return;
-                        }
+                        if (tokenStore.isRefreshTokenValidSafe(userId, refreshToken)) {
+                            // 정상: 현재 토큰 → rotate
+                            String newAccessToken  = jwtUtil.createAccessToken(userId);
+                            String newRefreshToken = jwtUtil.createRefreshToken(userId);
 
-                        // 2. Redis 현재값과 불일치 확인
-                        if (!tokenStore.isRefreshTokenValidSafe(userId, refreshToken)) {
-                            String prevJti = tokenStore.getPrevJti(userId);
-                            if (refreshJti.equals(prevJti)) {
-                                // 동시 회전 race condition — grace window 내 이전 토큰
-                                log.debug("Grace window hit for userId={}, allowing request", userId);
-                                setAuthentication(request, userId);
+                            // 회전되어 사라진 jti를 grace에 기록(값=새 토큰) + 보안용 장기 블랙리스트
+                            tokenStore.markGraceJti(refreshJti, newRefreshToken);
+                            tokenStore.blacklistRefreshToken(refreshJti, jwtUtil.getExpiration(refreshToken));
+                            tokenStore.saveRefreshToken(userId, newRefreshToken, jwtUtil.getRefreshTokenSeconds());
+
+                            addCookie(response, "REFRESH_TOKEN", newRefreshToken, (int) jwtUtil.getRefreshTokenSeconds());
+                            response.setHeader("X-New-Access-Token", newAccessToken);
+                            response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+                            log.debug("Token rotated for userId={}", userId);
+                        } else {
+                            // 현재 토큰 아님 → grace 확인 (최근 30s 내 회전된 토큰인가)
+                            String currentRefresh = tokenStore.getGraceCurrentTokenSafe(refreshJti);
+                            if (currentRefresh != null) {
+                                // 정상 동시성: 거부하지 않고 현재 토큰 쿠키로 수렴 + 새 access 발급 (재회전 X)
+                                log.debug("Grace hit — converging to current token. userId={}", userId);
+                                addCookie(response, "REFRESH_TOKEN", currentRefresh, (int) jwtUtil.getRefreshTokenSeconds());
+                                response.setHeader("X-New-Access-Token", jwtUtil.createAccessToken(userId));
+                                response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+                            } else {
+                                // grace window 밖의 옛 토큰 → 진짜 폐기/탈취 의심
+                                log.warn("Stale refresh token outside grace window. userId={}", userId);
+                                clearContext(response);
                                 filterChain.doFilter(request, response);
                                 return;
                             }
-                            // 진짜 탈취 의심
-                            log.warn("Refresh token mismatch. Possible token theft. userId={}", userId);
-                            clearContext(response);
-                            filterChain.doFilter(request, response);
-                            return;
                         }
-
-                        // 3. 정상 rotate
-                        String newAccessToken  = jwtUtil.createAccessToken(userId);
-                        String newRefreshToken = jwtUtil.createRefreshToken(userId);
-
-                        // 이전 jti를 grace window(10s)에 저장
-                        tokenStore.savePrevJti(userId, refreshJti);
-                        // 이전 refresh token을 블랙리스트에 등록 (잔여 TTL)
-                        tokenStore.blacklistRefreshToken(refreshJti, jwtUtil.getExpiration(refreshToken));
-                        // 새 refresh token 저장
-                        tokenStore.saveRefreshToken(userId, newRefreshToken, jwtUtil.getRefreshTokenSeconds());
-
-                        addCookie(response, "REFRESH_TOKEN", newRefreshToken, (int) jwtUtil.getRefreshTokenSeconds());
-                        // 새 Access Token은 응답 헤더로 전달 (JS가 메모리에 저장)
-                        response.setHeader("X-New-Access-Token", newAccessToken);
-                        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
-
-                        log.debug("Token rotated for userId={}", userId);
-
                     } finally {
                         tokenStore.releaseTokenRefreshLock(userId);
                     }
 
                 } else {
-                    // 락 획득 실패 — 다른 요청이 이미 rotate 중
-                    // rf_blacklist 확인 후 grace window로 처리
-                    if (tokenStore.isRefreshBlacklistedSafe(refreshJti)) {
-                        // 이미 rotate 완료되어 블랙리스트에 등록된 이전 토큰
-                        String prevJti = tokenStore.getPrevJti(userId);
-                        if (refreshJti.equals(prevJti)) {
-                            log.debug("Lock miss + grace window hit for userId={}", userId);
-                            setAuthentication(request, userId);
-                            filterChain.doFilter(request, response);
-                            return;
-                        }
-                        log.warn("Blacklisted refresh token used (no lock). userId={}", userId);
+                    // 락 미획득 — 다른 요청이 회전 중. 현재/ grace 토큰이면 회전 없이 인증만 유지.
+                    boolean current = tokenStore.isRefreshTokenValidSafe(userId, refreshToken);
+                    boolean grace   = tokenStore.getGraceCurrentTokenSafe(refreshJti) != null;
+                    if (!current && !grace) {
+                        log.warn("Stale refresh token on lock miss. userId={}", userId);
                         clearContext(response);
                         filterChain.doFilter(request, response);
                         return;
                     }
-                    log.debug("Token refresh lock not acquired for userId={}, skipping rotation", userId);
+                    log.debug("Lock miss — token current/grace, authenticating without rotation. userId={}", userId);
                 }
 
                 setAuthentication(request, userId);
@@ -188,6 +169,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (header != null && header.startsWith("Bearer ")) {
             return header.substring(7);
+        }
+        // EventSource(SSE)는 커스텀 헤더 불가 → SSE 경로에 한해 ?token= 쿼리의 access token 허용.
+        // 이렇게 하면 SSE가 access token으로 인증(branch ①)되어 refresh 회전을 유발하지 않는다.
+        if (request.getRequestURI().startsWith("/api/sse/")) {
+            String queryToken = request.getParameter("token");
+            if (queryToken != null && !queryToken.isBlank()) {
+                return queryToken;
+            }
         }
         return null;
     }

--- a/src/main/java/org/dallyeo/matuabom/auth/service/TokenStore.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/service/TokenStore.java
@@ -23,12 +23,14 @@ public class TokenStore {
     private static final String PREFIX_REFRESH      = "refresh:";
     private static final String PREFIX_BLACKLIST    = "blacklist:";
     private static final String PREFIX_RF_BLACKLIST = "rf_blacklist:";
-    private static final String PREFIX_PREV_JTI     = "prev_jti:";
+    private static final String PREFIX_GRACE        = "grace_jti:";
     private static final String PREFIX_INVITE       = "invite:";
     private static final String PREFIX_TOKEN_LOCK   = "token_refresh_lock:";
     private static final String PREFIX_AUTH_CODE    = "auth_code:";
 
-    private static final long GRACE_WINDOW_SECONDS = 10L;
+    // 회전 직후 grace window. 이 시간 내에 도착한 이전(직전 N세대) refresh 요청은
+    // 정상 동시성으로 보고 거부 대신 현재 토큰으로 수렴시킨다.
+    private static final long GRACE_WINDOW_SECONDS = 30L;
 
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -136,19 +138,35 @@ public class TokenStore {
         }
     }
 
-    // ── prev_jti grace window ──────────────────────────────────────────────────
+    // ── grace window (회전된 jti → 현재 refresh token) ──────────────────────────
 
     /**
-     * rotate 직후 이전 jti를 10초 grace window로 저장.
-     * 동시 요청 race condition에서 이전 토큰을 허용하기 위한 용도.
+     * rotate 직후 "회전되어 사라진" jti를 grace 키로 기록한다.
+     * 값으로 회전 결과의 "현재" refresh token을 저장해, grace 내에 도착한 이전 토큰 요청을
+     * 거부하지 않고 현재 토큰으로 수렴시킬 수 있게 한다.
+     * 각 jti가 독립 키(TTL 30s)라 직전 2세대 이상의 동시 회전도 자연히 관용된다.
      */
-    public void savePrevJti(String userId, String jti) {
+    public void markGraceJti(String oldJti, String currentRefreshToken) {
         redisTemplate.opsForValue()
-                .set(PREFIX_PREV_JTI + userId, jti, Duration.ofSeconds(GRACE_WINDOW_SECONDS));
+                .set(PREFIX_GRACE + oldJti, currentRefreshToken, Duration.ofSeconds(GRACE_WINDOW_SECONDS));
     }
 
-    public String getPrevJti(String userId) {
-        return redisTemplate.opsForValue().get(PREFIX_PREV_JTI + userId);
+    /**
+     * grace window 내에 회전된 jti면 "현재" refresh token을 반환, 아니면 null.
+     */
+    public String getGraceCurrentToken(String oldJti) {
+        return redisTemplate.opsForValue().get(PREFIX_GRACE + oldJti);
+    }
+
+    /**
+     * Redis 다운 시 null 반환 (grace 미적용) — 안전 측.
+     */
+    public String getGraceCurrentTokenSafe(String oldJti) {
+        try {
+            return getGraceCurrentToken(oldJti);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     // ── InviteCode 캐시 ────────────────────────────────────────────────────────


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #97

## 📝 작업 내용
> refresh 토큰 회전 race로 인한 주기적 로그아웃 수정 (운영 로그로 원인 확정)

- grace 재설계: 단일 prevJti·10초 → 회전된 jti별 grace 키(값=현재 refresh token)·30초. 직전 2세대 이상 동시 회전도 관용
- 블랙리스트보다 grace 우선: 최근 회전된 토큰은 거부 대신 현재 토큰 쿠키로 수렴 + 새 access 발급(재회전 X)
- grace window 밖의 옛 토큰만 진짜 폐기/탈취로 거부
- SSE 회전 churn 제거: `JwtAuthFilter`가 `/api/sse` 경로에서 `?token=` access token을 Bearer처럼 인식 → SSE가 refresh 회전을 유발하지 않음

### ✨ 스크린샷

### 💬 리뷰 요구사항
- 회전/탈취 감지 로직 변경이라 grace window(30s) 적절성 검토 요망

Closes #97