### PR TITLE
feature : 개인정보/약관 동의 서버 기록 (1회 동의) (#99)

### DIFF
--- a/src/main/java/org/dallyeo/matuabom/auth/controller/AuthController.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/controller/AuthController.java
@@ -38,6 +38,7 @@ public class AuthController {
     private final TokenStore tokenStore;
     private final JwtUtil jwtUtil;
     private final UserWithdrawalService userWithdrawalService;
+    private final org.dallyeo.matuabom.user.service.UserService userService;
 
     @Value("${app.cookie-secure:false}")
     private boolean cookieSecure;
@@ -50,6 +51,18 @@ public class AuthController {
         UserEntity user = userRepository.findByMongoId(principal.getUserId())
                 .orElseThrow(() -> new UsernameNotFoundException("user not found"));
         return ResponseEntity.ok(MeDto.createDto(user));
+    }
+
+    /**
+     * 약관/개인정보처리방침 동의를 서버에 기록한다 (최초 1회).
+     */
+    @PostMapping("/api/auth/terms")
+    public ResponseEntity<Void> agreeTerms(@AuthenticationPrincipal CustomPrincipal principal) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        userService.agreeTerms(principal.getUserId());
+        return ResponseEntity.ok().build();
     }
 
     /**

--- a/src/main/java/org/dallyeo/matuabom/user/domain/UserEntity.java
+++ b/src/main/java/org/dallyeo/matuabom/user/domain/UserEntity.java
@@ -30,6 +30,9 @@ import java.time.Instant;
 @AllArgsConstructor
 public class UserEntity {
 
+    /** 현재 약관/개인정보처리방침 버전. 개정 시 이 값을 올리면 재동의를 받는다. */
+    public static final String CURRENT_TERMS_VERSION = "1";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -53,6 +56,14 @@ public class UserEntity {
     @Column(name = "google_linked")
     @Builder.Default
     private boolean googleLinked = false;
+
+    /** 약관/개인정보 동의 시각 (미동의 시 null) */
+    @Column(name = "terms_agreed_at")
+    private Instant termsAgreedAt;
+
+    /** 동의한 약관 버전 */
+    @Column(name = "terms_version", length = 20)
+    private String termsVersion;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @Builder.Default

--- a/src/main/java/org/dallyeo/matuabom/user/dto/MeDto.java
+++ b/src/main/java/org/dallyeo/matuabom/user/dto/MeDto.java
@@ -15,9 +15,13 @@ public class MeDto {
     private String nickname;
     private String profileImageUrl;
     private Instant createdAt;
+    /** 현재 약관 버전에 동의했는지 여부 (false면 동의 게이트 노출) */
+    private boolean termsAgreed;
 
     public static MeDto createDto(UserEntity user) {
         String id = user.getMongoId() != null ? user.getMongoId() : String.valueOf(user.getId());
-        return new MeDto(id, user.getNickname(), user.getProfileImageUrl(), user.getCreatedAt());
+        boolean termsAgreed = user.getTermsAgreedAt() != null
+                && UserEntity.CURRENT_TERMS_VERSION.equals(user.getTermsVersion());
+        return new MeDto(id, user.getNickname(), user.getProfileImageUrl(), user.getCreatedAt(), termsAgreed);
     }
 }

--- a/src/main/java/org/dallyeo/matuabom/user/service/UserService.java
+++ b/src/main/java/org/dallyeo/matuabom/user/service/UserService.java
@@ -58,6 +58,15 @@ public class UserService {
         return user.getMongoId() != null ? user.getMongoId() : String.valueOf(user.getId());
     }
 
+    /** 현재 약관 버전에 대한 동의를 기록한다. */
+    @Transactional
+    public void agreeTerms(String userId) {
+        UserEntity user = findById(userId);
+        user.setTermsAgreedAt(java.time.Instant.now());
+        user.setTermsVersion(UserEntity.CURRENT_TERMS_VERSION);
+        userJpaRepository.save(user);
+    }
+
     @Transactional
     public void linkGoogleEmail(String userId, String googleEmail) {
         UserEntity user = findById(userId);


### PR DESCRIPTION
﻿## #️⃣ 연관된 이슈
> #99

## 📝 작업 내용
> 개인정보/약관 동의를 계정에 1회 기록

- UserEntity에 terms_agreed_at, terms_version 컬럼 + CURRENT_TERMS_VERSION 상수
- MeDto.termsAgreed(boolean) 노출 (현재 버전 일치 여부)
- POST /api/auth/terms 동의 기록 API + UserService.agreeTerms

## ⚠️ 배포 전 필수 (prod ddl-auto=validate)
배포 전 prod Postgres에 컬럼을 먼저 추가해야 기동 검증을 통과합니다:
```sql
ALTER TABLE users
  ADD COLUMN terms_agreed_at timestamptz,
  ADD COLUMN terms_version varchar(20);
```

### 💬 리뷰 요구사항
- ALTER TABLE 선행 후 머지

Closes #99
