### PR TITLE
refactor : 미사용 토큰 블랙리스트 dead code 제거 (#101)

### DIFF
--- a/src/main/java/org/dallyeo/matuabom/auth/controller/AuthController.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/controller/AuthController.java
@@ -1,13 +1,11 @@
 package org.dallyeo.matuabom.auth.controller;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dallyeo.matuabom.auth.service.TokenStore;
-import org.dallyeo.matuabom.global.util.JwtUtil;
 import org.dallyeo.matuabom.user.domain.UserEntity;
 import org.dallyeo.matuabom.user.dto.MeDto;
 import org.dallyeo.matuabom.user.repository.jpa.UserJpaRepository;
@@ -26,7 +24,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Map;
 
 @Slf4j
@@ -36,7 +33,6 @@ public class AuthController {
 
     private final UserJpaRepository userRepository;
     private final TokenStore tokenStore;
-    private final JwtUtil jwtUtil;
     private final UserWithdrawalService userWithdrawalService;
     private final org.dallyeo.matuabom.user.service.UserService userService;
 
@@ -104,15 +100,7 @@ public class AuthController {
             HttpServletResponse response,
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
-        // ① Refresh Token → rf_blacklist 등록 + Redis 삭제
-        String refreshToken = extractCookie(request, "REFRESH_TOKEN");
-        if (refreshToken != null) {
-            try {
-                tokenStore.blacklistRefreshToken(jwtUtil.getJti(refreshToken), jwtUtil.getExpiration(refreshToken));
-            } catch (Exception e) {
-                log.warn("Failed to blacklist refresh token: {}", e.getMessage());
-            }
-        }
+        // ① Refresh Token Redis에서 삭제 → 이후 현재 토큰 불일치로 거부됨 (무효화)
         if (principal != null) {
             tokenStore.deleteRefreshToken(principal.getUserId());
         }
@@ -153,15 +141,6 @@ public class AuthController {
     }
 
     // ── 내부 헬퍼 ──────────────────────────────────────────────────────────────
-
-    private String extractCookie(HttpServletRequest request, String name) {
-        if (request.getCookies() == null) return null;
-        return Arrays.stream(request.getCookies())
-                .filter(c -> name.equals(c.getName()))
-                .map(Cookie::getValue)
-                .findFirst()
-                .orElse(null);
-    }
 
     private void expireCookie(HttpServletResponse response, String name) {
         ResponseCookie cookie = ResponseCookie.from(name, "")

--- a/src/main/java/org/dallyeo/matuabom/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/filter/JwtAuthFilter.java
@@ -46,17 +46,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String accessToken  = extractBearerToken(request);
         String refreshToken = extractCookie(request, "REFRESH_TOKEN");
 
-        // ① Access Token 유효 + 블랙리스트에 없는 경우 → 정상 인증
+        // ① Access Token 유효 → 정상 인증
         if (accessToken != null) {
             try {
-                String jti = jwtUtil.getJti(accessToken);
-
-                if (tokenStore.isBlacklistedSafe(jti)) {
-                    clearContext(response);
-                    filterChain.doFilter(request, response);
-                    return;
-                }
-
                 String userId = jwtUtil.validateAndGetSub(accessToken);
 
                 if (!"access".equals(jwtUtil.getTokenType(accessToken))) {
@@ -96,9 +88,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                             String newAccessToken  = jwtUtil.createAccessToken(userId);
                             String newRefreshToken = jwtUtil.createRefreshToken(userId);
 
-                            // 회전되어 사라진 jti를 grace에 기록(값=새 토큰) + 보안용 장기 블랙리스트
+                            // 회전되어 사라진 jti를 grace window에 기록(값=새 토큰) — 직전 토큰을 든 정상 동시 요청을 현재 토큰으로 수렴
                             tokenStore.markGraceJti(refreshJti, newRefreshToken);
-                            tokenStore.blacklistRefreshToken(refreshJti, jwtUtil.getExpiration(refreshToken));
                             tokenStore.saveRefreshToken(userId, newRefreshToken, jwtUtil.getRefreshTokenSeconds());
 
                             addCookie(response, "REFRESH_TOKEN", newRefreshToken, (int) jwtUtil.getRefreshTokenSeconds());

--- a/src/main/java/org/dallyeo/matuabom/auth/service/TokenStore.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/service/TokenStore.java
@@ -5,24 +5,19 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.time.Instant;
 
 /**
  * Redis 기반 토큰 저장소.
  *
  * 키 구조:
  *   refresh:{userId}          → refresh token 값 (TTL = refresh 유효기간)
- *   blacklist:{jti}           → "1"            (TTL = access token 잔여 유효기간)
- *   rf_blacklist:{jti}        → "1"            (TTL = refresh token 잔여 유효기간)
- *   prev_jti:{userId}         → 이전 rotate된 refresh jti (TTL = 10s grace window)
+ *   grace_jti:{jti}           → 회전된 jti → 현재 refresh token (TTL = grace window)
  */
 @Component
 @RequiredArgsConstructor
 public class TokenStore {
 
     private static final String PREFIX_REFRESH      = "refresh:";
-    private static final String PREFIX_BLACKLIST    = "blacklist:";
-    private static final String PREFIX_RF_BLACKLIST = "rf_blacklist:";
     private static final String PREFIX_GRACE        = "grace_jti:";
     private static final String PREFIX_INVITE       = "invite:";
     private static final String PREFIX_TOKEN_LOCK   = "token_refresh_lock:";
@@ -69,35 +64,6 @@ public class TokenStore {
         redisTemplate.delete(PREFIX_TOKEN_LOCK + userId);
     }
 
-    // ── Access Token 블랙리스트 ────────────────────────────────────────────────
-
-    /**
-     * 로그아웃 시 access token을 블랙리스트에 등록.
-     * Redis 키: blacklist:{jti} — JWT 전체 문자열 대신 UUID(jti)만 저장해 메모리 절약.
-     */
-    public void blacklistAccessToken(String jti, Instant expiresAt) {
-        long remainingSeconds = expiresAt.getEpochSecond() - Instant.now().getEpochSecond();
-        if (remainingSeconds > 0) {
-            redisTemplate.opsForValue()
-                    .set(PREFIX_BLACKLIST + jti, "1", Duration.ofSeconds(remainingSeconds));
-        }
-    }
-
-    public boolean isBlacklisted(String jti) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX_BLACKLIST + jti));
-    }
-
-    /**
-     * Redis 다운 시 false 반환 (블랙리스트 체크 스킵) — JWT 서명은 상위에서 이미 검증됨
-     */
-    public boolean isBlacklistedSafe(String jti) {
-        try {
-            return isBlacklisted(jti);
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
     /**
      * Redis 다운 시 true 반환 (유효한 것으로 간주) — JWT 서명은 상위에서 이미 검증됨
      */
@@ -106,35 +72,6 @@ public class TokenStore {
             return isRefreshTokenValid(userId, refreshToken);
         } catch (Exception e) {
             return true;
-        }
-    }
-
-    // ── Refresh Token 블랙리스트 ───────────────────────────────────────────────
-
-    /**
-     * 로그아웃 또는 rotate 시 이전 refresh token jti를 블랙리스트에 등록.
-     * Redis 키: rf_blacklist:{jti} (TTL = refresh token 잔여 유효기간)
-     */
-    public void blacklistRefreshToken(String jti, Instant expiresAt) {
-        long remainingSeconds = expiresAt.getEpochSecond() - Instant.now().getEpochSecond();
-        if (remainingSeconds > 0) {
-            redisTemplate.opsForValue()
-                    .set(PREFIX_RF_BLACKLIST + jti, "1", Duration.ofSeconds(remainingSeconds));
-        }
-    }
-
-    public boolean isRefreshBlacklisted(String jti) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX_RF_BLACKLIST + jti));
-    }
-
-    /**
-     * Redis 다운 시 false 반환 (스킵) — 가용성 우선
-     */
-    public boolean isRefreshBlacklistedSafe(String jti) {
-        try {
-            return isRefreshBlacklisted(jti);
-        } catch (Exception e) {
-            return false;
         }
     }
 


### PR DESCRIPTION
﻿## #️⃣ 연관된 이슈
> #97 후속 / Closes #101

## 📝 작업 내용
> refresh 회전 재설계 이후 미사용 상태가 된 토큰 블랙리스트 dead code 제거

- JwtAuthFilter: access 블랙리스트 검사(branch ①) 및 회전 시 refresh 블랙리스트 기록 제거
- AuthController.logout: refresh 블랙리스트 기록 제거(무효화는 deleteRefreshToken 유지), 미사용 jwtUtil 필드·extractCookie·관련 import 정리
- TokenStore: blacklistAccessToken/isBlacklisted(Safe)/blacklistRefreshToken/isRefreshBlacklisted(Safe) 및 PREFIX_BLACKLIST/PREFIX_RF_BLACKLIST·Instant import 제거

## 기능 영향
- 없음. 무효화는 Redis 현재 토큰 일치 검증 + 로그아웃 시 삭제로 그대로 동작
- 컴파일 검증 완료

Closes #101
