### PR TITLE
fix : OAuth 실패 프론트 리다이렉트 + 4xx 에러 응답 정합화 (#110)

### DIFF
--- a/src/main/java/org/dallyeo/matuabom/auth/handler/JwtLoginFailureHandler.java
+++ b/src/main/java/org/dallyeo/matuabom/auth/handler/JwtLoginFailureHandler.java
@@ -1,0 +1,63 @@
+package org.dallyeo.matuabom.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Duration;
+
+/**
+ * OAuth 로그인 실패 시 처리.
+ *
+ * 기본 실패 핸들러는 백엔드의 {@code /login?error}로 리다이렉트하는데,
+ * 이 앱은 API 서버라 그 경로가 없어 정적리소스 500이 발생한다.
+ * 대신 프론트엔드의 로그인 페이지로 리다이렉트한다.
+ */
+@Slf4j
+@Component
+public class JwtLoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Value("${app.frontend-base-url:http://localhost:3000}")
+    private String frontendBaseUrl;
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception
+    ) throws IOException {
+        log.warn("OAuth 로그인 실패: {}", exception.getMessage());
+        cleanupSession(request, response);
+        response.sendRedirect(frontendBaseUrl + "/login?error=oauth");
+    }
+
+    private void cleanupSession(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            HttpSession session = request.getSession(false);
+            if (session != null) {
+                try {
+                    session.invalidate();
+                } catch (IllegalStateException ignored) {
+                }
+            }
+            SecurityContextHolder.clearContext();
+
+            ResponseCookie expiredSessionCookie = ResponseCookie.from("JSESSIONID", "")
+                    .path("/")
+                    .httpOnly(true)
+                    .maxAge(Duration.ofSeconds(0))
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, expiredSessionCookie.toString());
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/src/main/java/org/dallyeo/matuabom/global/config/SecurityConfig.java
+++ b/src/main/java/org/dallyeo/matuabom/global/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
 
     private final KakaoOAuth2UserService kakaoOAuth2UserService;
     private final JwtLoginSuccessHandler jwtLoginSuccessHandler;
+    private final org.dallyeo.matuabom.auth.handler.JwtLoginFailureHandler jwtLoginFailureHandler;
     private final JwtAuthFilter jwtAuthFilter;
     private final RateLimitFilter rateLimitFilter;
     private final AdminSecretFilter adminSecretFilter;
@@ -81,6 +82,7 @@ public class SecurityConfig {
                             return new DefaultOAuth2UserService().loadUser(oauth2UserRequest);
                         }))
                         .successHandler(jwtLoginSuccessHandler)
+                        .failureHandler(jwtLoginFailureHandler)
                 )
                 .oauth2Client(Customizer.withDefaults())
                 .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/org/dallyeo/matuabom/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/dallyeo/matuabom/global/exception/GlobalExceptionHandler.java
@@ -7,8 +7,11 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.Map;
 
@@ -42,6 +45,22 @@ public class GlobalExceptionHandler {
         log.warn("Validation failed: {}", message);
         return ResponseEntity.badRequest()
                 .body(Map.of("error", "validation_failed", "message", message));
+    }
+
+    // 400 — 필수 파라미터 누락 / 파라미터 타입 불일치 (기존엔 catch-all 500로 빠지던 것)
+    @ExceptionHandler({MissingServletRequestParameterException.class, MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<Map<String, String>> handleBadRequestParams(Exception e) {
+        log.warn("Bad request parameter: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(Map.of("error", "bad_request", "message", "요청 파라미터가 올바르지 않습니다."));
+    }
+
+    // 404 — 정적 리소스 미존재 (/favicon.ico, /robots.txt, /login 등 — 기존엔 500 노이즈)
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNoResource(NoResourceFoundException e) {
+        log.debug("No static resource: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", "not_found", "message", "리소스를 찾을 수 없습니다."));
     }
 
     // 400 — 아직 교체 안 된 IllegalArgumentException


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Closes #110

## 📝 작업 내용
배포 검증 중 관측된 500 노이즈/UX 개선 3건.

### 주요 변경
1. **OAuth 실패 → 프론트 리다이렉트** — `JwtLoginFailureHandler` 신규. 기존엔 `failureHandler` 미설정이라 Spring 기본값(백엔드 `/login?error`)으로 가서 정적리소스 500 발생. 이제 `frontend-base-url/login?error=oauth`로 리다이렉트(+세션 정리). SecurityConfig `.failureHandler(...)` 배선.
2. **누락/타입불일치 파라미터 → 400** — `MissingServletRequestParameterException`·`MethodArgumentTypeMismatchException`이 catch-all(500)로 빠지던 것 수정.
3. **정적리소스 미존재 → 404** — `NoResourceFoundException`(`/favicon.ico`·`/robots.txt`·`/login` 등) 500 노이즈 제거.

### ✅ 검증
- [x] `./gradlew compileJava` 성공
- [ ] 머지 후 자동배포 → OAuth 실패/누락파라미터 응답 확인 예정

### 💬 리뷰 요구사항
1. 에러 응답 상태코드만 정합화, 정상 로그인 플로우는 불변.
2. 머지 시 develop→자동배포 트리거.
