### PR TITLE
fix : Google 캘린더 범위 최소화 (calendar → calendar.events) (#112)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,9 @@ spring:
               - openid
               - profile
               - email
-              - https://www.googleapis.com/auth/calendar
+              # 앱은 events()만 사용(list/insert/update/delete/watch) → 최소 범위 calendar.events.
+              # Google 검증 제출 범위와 일치시켜야 함(전체 calendar 아님).
+              - https://www.googleapis.com/auth/calendar.events
 
           kakao:
             client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Closes #112

## 📝 작업 내용
Google OAuth 검증 대응 — 캘린더 범위를 최소화한다.

### 주요 변경
1. `application.yml` Google scope: `.../auth/calendar` → **`.../auth/calendar.events`**
2. 앱은 Google Calendar API의 `events()`만 사용(list/insert/get/update/delete/watch) — calendarList/freebusy/acl/settings 미사용 확인 → 기능 영향 없음

### ✅ 검증
- [x] 스코프 참조는 application.yml 1곳뿐 확인
- [ ] 머지 후 자동배포 → 동의화면이 calendar.events만 요청하는지 확인

### 💬 리뷰 요구사항
1. 검증 제출 범위(calendar.events)와 앱 요청 범위 일치 (지적 #3 해결).
2. 기존 구글 연동 사용자는 범위 변경으로 재동의 필요(현재 1명).